### PR TITLE
Add autoload to helm-projectile-toggle

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -811,6 +811,7 @@ DIR is the project root, if not set then current directory is used"
     "Find recently visited file in project."
     (helm-projectile-recentf)))
 
+;;;###autoload
 (defun helm-projectile-toggle (toggle)
   "Toggle Helm version of Projectile commands."
   (if (> toggle 0)


### PR DESCRIPTION
So that I can invoke `helm-projectile-toggle` via `use-package` without "might not be defined at runtime" flycheck message.

Why not use `helm-projectile-on`? Because I do not want `(message "Turn on helm-projectile key bindings")` to run, and I'm not yet using Emacs 25 to use `inhibit-message`.

Thank you.