### PR TITLE
Revise description for "delete project" command

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -166,7 +166,7 @@ DIR is the project root."
     (projectile-run-project helm-current-prefix-arg)))
 
 (defun helm-projectile-remove-known-project (_ignore)
-  "Delete selected projects.
+  "Remove selected projects from projectile project list.
 _IGNORE means the argument does not matter.
 It is there because Helm requires it."
   (let* ((projects (helm-marked-candidates :with-wildcard t))
@@ -174,14 +174,14 @@ It is there because Helm requires it."
     (with-helm-display-marked-candidates
       helm-marked-buffer-name
       projects
-      (if (not (y-or-n-p (format "Delete *%s projects(s)? " len)))
-          (message "(No deletion performed)")
+      (if (not (y-or-n-p (format "Remove *%s projects(s)? " len)))
+          (message "(No removal performed)")
         (progn
           (mapc (lambda (p)
                   (delete p projectile-known-projects))
                 projects)
           (projectile-save-known-projects))
-        (message "%s projects(s) deleted" len)))))
+        (message "%s projects(s) removed" len)))))
 
 (defvar helm-projectile-projects-map
   (let ((map (make-sparse-keymap)))
@@ -218,7 +218,7 @@ It is there because Helm requires it."
               ("Grep in projects `C-s'" . helm-projectile-grep)
               ("Compile project `M-c'. With C-u, new compile command"
                . helm-projectile-compile-project)
-              ("Remove project(s) `M-D'" . helm-projectile-remove-known-project)))
+              ("Remove project(s) from project list `M-D'" . helm-projectile-remove-known-project)))
   "Helm source for known projectile projects.")
 
 (define-key helm-etags-map (kbd "C-c p f")


### PR DESCRIPTION
This is a suggestion / request to re-word the delete project command and make it consistent with existing label "Remove project(s) `M-D'".  "Delete" can be a dangerous verb and the description doesn't entirely preclude the possibility that files could be deleted.  I suggest "remove" with a slightly more verbose explanation of the action.

What do you think?  It does break the pure mnemonic `M-D', but that doesn't violate the aesthetic in my eyes.

Thanks for the package :-)  :+1: