### PR TITLE
Allow grep actions to be customized

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -654,6 +654,17 @@ Other file extensions can be customized with the variable `projectile-other-file
                   :prompt (projectile-prepend-project-name "Find other file: ")))))
     (error "No other file found")))
 
+(defvar helm-projectile-grep-or-ack-actions
+  '("Find file" helm-grep-action
+    "Find file other frame" helm-grep-other-frame
+    (lambda () (and (locate-library "elscreen")
+               "Find file in Elscreen"))
+    helm-grep-jump-elscreen
+    "Save results in grep buffer" helm-grep-save-results
+    "Find file other window" helm-grep-other-window)
+  "Available actions for `helm-projectile-grep-or-ack'.
+The contents of this list are passed as the arguments to `helm-make-actions'")
+
 (defun helm-projectile-grep-or-ack (&optional dir use-ack-p ack-ignored-pattern ack-executable)
   "Perform helm-grep at project root.
 DIR directory where to search
@@ -692,14 +703,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
             ;; to make it available in further resuming.
             :keymap helm-grep-map
             :history 'helm-grep-history
-            :action (helm-make-actions
-                     "Find file" 'helm-grep-action
-                     "Find file other frame" 'helm-grep-other-frame
-                     (lambda () (and (locate-library "elscreen")
-                                     "Find file in Elscreen"))
-                     'helm-grep-jump-elscreen
-                     "Save results in grep buffer" 'helm-grep-save-results
-                     "Find file other window" 'helm-grep-other-window)
+            :action (apply #'helm-make-actions helm-projectile-grep-or-ack-actions)
             :persistent-action 'helm-grep-persistent-action
             :persistent-help "Jump to line (`C-u' Record in mark ring)"
             :requires-pattern 2))

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -654,7 +654,7 @@ Other file extensions can be customized with the variable `projectile-other-file
                   :prompt (projectile-prepend-project-name "Find other file: ")))))
     (error "No other file found")))
 
-(defvar helm-projectile-grep-or-ack-actions
+(defcustom helm-projectile-grep-or-ack-actions
   '("Find file" helm-grep-action
     "Find file other frame" helm-grep-other-frame
     (lambda () (and (locate-library "elscreen")
@@ -663,7 +663,8 @@ Other file extensions can be customized with the variable `projectile-other-file
     "Save results in grep buffer" helm-grep-save-results
     "Find file other window" helm-grep-other-window)
   "Available actions for `helm-projectile-grep-or-ack'.
-The contents of this list are passed as the arguments to `helm-make-actions'")
+The contents of this list are passed as the arguments to `helm-make-actions'."
+  :group 'helm-projectile)
 
 (defun helm-projectile-grep-or-ack (&optional dir use-ack-p ack-ignored-pattern ack-executable)
   "Perform helm-grep at project root.


### PR DESCRIPTION
This PR makes it possible to customize the helm "actions" that are available when using `helm-projectile-grep`. So with this, one can add a new action as follows:

```emacs-lisp
(setq helm-projectile-grep-or-ack-actions
      (append helm-projectile-grep-or-ack-actions
              '("My new action"
                my-new-action-function)))
```

AIUI it is not possible to use the usual helm API `helm-add-action-to-source`, because `helm-projectile-grep-or-ack` [overwrites](https://github.com/bbatsov/helm-projectile/blob/master/helm-projectile.el#L679) the source.