### PR TITLE
remove trailing "/" in ignored directories so that Helm can recognize Projectile's configuration

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -669,9 +669,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
          (helm-grep-in-recurse t)
          (helm-grep-ignored-files (-union (projectile-ignored-files-rel)  grep-find-ignored-files))
          (helm-grep-ignored-directories
-          (-union (--map (and (string-suffix-p "/" it)
-                              (substring it 0 -1))
-                         (projectile-ignored-directories-rel))
+          (-union (-map 'directory-file-name (projectile-ignored-directories-rel))
                   grep-find-ignored-directories))
          (helm-grep-default-command (if use-ack-p
                                         (concat ack-executable " -H --no-group --no-color " ack-ignored-pattern " %p %f")

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -668,7 +668,11 @@ If it is nil, or ack/ack-grep not found then use default grep command."
                       (assoc-default 'follow helm-source-grep)))
          (helm-grep-in-recurse t)
          (helm-grep-ignored-files (-union (projectile-ignored-files-rel)  grep-find-ignored-files))
-         (helm-grep-ignored-directories (-union (projectile-ignored-directories-rel) grep-find-ignored-directories))
+         (helm-grep-ignored-directories
+          (-union (--map (and (string-suffix-p "/" it)
+                              (substring it 0 -1))
+                         (projectile-ignored-directories-rel))
+                  grep-find-ignored-directories))
          (helm-grep-default-command (if use-ack-p
                                         (concat ack-executable " -H --no-group --no-color " ack-ignored-pattern " %p %f")
                                       (if (and projectile-use-git-grep (eq (projectile-project-vcs) 'git))


### PR DESCRIPTION
Hi,

When using `helm-projectile-grep`, I encountered a problem that Helm-Projectile still searches through directories which are ignored by Projectile (setting in the file .projectile). This problem was also discussed by an user in Stackexchange: http://emacs.stackexchange.com/questions/17801/projectile-grep-file-filter

After investigation, I figured out a possible reason is that Helm-Projectile get a list of ignored directories by invoking `(projectile-ignored-directories-rel)`. Names of directories returned by this function all contain a trailing forward slash `/`. If this trailing forward slash `/` is removed before assigned to the variable `helm-grep-ignored-directories`, then `helm-projectile-grep` will ignore these folders.

So, I'd like to ask if this is a root cause of the problem?

If yes, then I also created an initial patch for it. Do you think if it is a right way to fix it?

And if yes, please feel free to merge into your repository.

Bests,
Trung.



