### PR TITLE
Preview instead of find file with persistent action

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -226,6 +226,18 @@ It is there because Helm requires it."
     (interactive)
     (helm-run-after-exit 'helm-projectile-find-file nil)))
 
+(defun helm-projectile-file-persistent-action (candidate)
+  "Persistent action for file-related functionality.
+
+Previews the contents of a file in a temporary buffer."
+  (switch-to-buffer (get-buffer-create " *helm-projectile persistent*"))
+  (fundamental-mode)
+  (erase-buffer)
+  (insert-file-contents candidate)
+  (let ((buffer-file-name candidate))
+    (set-auto-mode)
+    (font-lock-ensure)))
+
 (defun helm-projectile-find-files-eshell-command-on-file-action (_candidate)
   (interactive)
   (let* ((helm-ff-default-directory (file-name-directory _candidate)))
@@ -422,7 +434,8 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
     :keymap helm-projectile-find-file-map
     :help-message helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string
-    :action helm-projectile-file-actions))
+    :action helm-projectile-file-actions
+    :persistent-action #'helm-projectile-file-persistent-action))
 
 (defvar helm-source-projectile-files-list
   (helm-build-in-buffer-source "Projectile files"
@@ -436,6 +449,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
     :help-message 'helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string
     :action helm-projectile-file-actions
+    :persistent-action #'helm-projectile-file-persistent-action
     )
   "Helm source definition for Projectile files.")
 
@@ -450,6 +464,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
     :help-message 'helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string
     :action helm-projectile-file-actions
+    :persistent-action #'helm-projectile-file-persistent-action
     )
   "Helm source definition for all Projectile files in all projects.")
 
@@ -572,6 +587,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
     :help-message 'helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string
     :action helm-projectile-file-actions
+    :persistent-action #'helm-projectile-file-persistent-action
     )
   "Helm source definition for recent files in current project.")
 
@@ -658,7 +674,8 @@ Other file extensions can be customized with the variable `projectile-other-file
                                          map)
                                :help-message helm-ff-help-message
                                :mode-line helm-read-file-name-mode-line-string
-                               :action helm-projectile-file-actions)
+                               :action helm-projectile-file-actions
+                               :persistent-action #'helm-projectile-file-persistent-action)
                     :buffer "*helm projectile*"
                     :prompt (projectile-prepend-project-name "Find other file: ")))))
       (error "No other file found"))))


### PR DESCRIPTION
Address #56 by using `helm-projectile-file-persistent-action` where derivatives of `helm-find-files-action` are used.