### PR TITLE
Display real

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1,4 +1,4 @@
-;;; helm-projectile.el --- Helm integration for Projectile
+;;; helm-projectile.el --- Helm integration for Projectile         -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011-2016 Bozhidar Batsov
 


### PR DESCRIPTION
Address #64.

Fundamentally, the use of `coerce` and reliance on `helm-candidate-buffer` is the wrong thing to do. Instead, Helm source candidates should be `(DISPLAY . REAL)` pairs, where `DISPLAY` is the short file name and `REAL` is the full path.

cc @bbatsov 