### PR TITLE
Make line truncation in helm buffers customizable.

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -64,7 +64,12 @@
 (defvar helm-projectile-current-project-root)
 
 (defcustom helm-projectile-truncate-lines nil
-  "Truncate lines in helm projectile commands when non--nil."
+  "Truncate lines in helm projectile commands when non--nil.
+
+Some helm-projectile commands have similar behavior with existing
+Helms. In these cases their respective custom var for truncation
+of lines will be honored. E.g. `helm-buffers-truncate-lines'
+dictates the truncation in `helm-projectile-switch-to-buffer'."
   :group 'helm-projectile
   :type 'boolean)
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -63,6 +63,11 @@
 
 (defvar helm-projectile-current-project-root)
 
+(defcustom helm-projectile-truncate-lines nil
+  "Truncate lines in helm projectile commands when non--nil."
+  :group 'helm-projectile
+  :type 'boolean)
+
 ;;;###autoload
 (defcustom helm-projectile-fuzzy-match t
   "Enable fuzzy matching for Helm Projectile commands.
@@ -675,6 +680,7 @@ With a prefix ARG invalidates the cache first."
            (helm-boring-file-regexp-list nil))
        (helm :sources ,source
              :buffer "*helm projectile*"
+             :truncate-lines helm-projectile-truncate-lines
              :prompt (projectile-prepend-project-name ,prompt)))))
 
 (helm-projectile-command "switch-project" 'helm-source-projectile-projects "Switch to project: " t)
@@ -714,6 +720,7 @@ With a prefix ARG invalidates the cache first."
                        :persistent-action #'helm-projectile-file-persistent-action
                        :persistent-help "Preview file")
             :buffer "*helm projectile*"
+            :truncate-lines helm-projectile-truncate-lines
             :prompt (projectile-prepend-project-name "Find file: ")))))
 
 ;;;###autoload
@@ -743,6 +750,7 @@ Other file extensions can be customized with the variable `projectile-other-file
                                :persistent-action #'helm-projectile-file-persistent-action
                                :persistent-help "Preview file")
                     :buffer "*helm projectile*"
+                    :truncate-lines helm-projectile-truncate-lines
                     :prompt (projectile-prepend-project-name "Find other file: ")))))
       (error "No other file found"))))
 
@@ -825,7 +833,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
      :default-directory default-directory
      :keymap helm-grep-map
      :history 'helm-grep-history
-     :truncate-lines t)))
+     :truncate-lines helm-projectile-truncate-lines)))
 
 ;;;###autoload
 (defun helm-projectile-on ()
@@ -974,6 +982,7 @@ If invoked outside of a project, displays a list of known projects to jump."
   (let ((helm-ff-transformer-show-only-basename nil))
     (helm :sources helm-projectile-sources-list
           :buffer "*helm projectile*"
+          :truncate-lines helm-projectile-truncate-lines
           :prompt (projectile-prepend-project-name (if (projectile-project-p)
                                                        "pattern: "
                                                      "Switch to project: ")))))

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -659,13 +659,14 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
   "Default sources for `helm-projectile'."
   :group 'helm-projectile)
 
-(defmacro helm-projectile-command (command source prompt &optional not-require-root)
+(defmacro helm-projectile-command (command source prompt &optional not-require-root truncate-lines-var)
   "Template for generic helm-projectile commands.
 COMMAND is a command name to be appended with \"helm-projectile\" prefix.
 SOURCE is a Helm source that should be Projectile specific.
 PROMPT is a string for displaying as a prompt.
 NOT-REQUIRE-ROOT specifies the command doesn't need to be used in a
 project root."
+  (unless truncate-lines-var (setq truncate-lines-var 'helm-projectile-truncate-lines))
   `(defun ,(intern (concat "helm-projectile-" command)) (&optional arg)
      "Use projectile with Helm for finding files in project
 
@@ -680,7 +681,7 @@ With a prefix ARG invalidates the cache first."
            (helm-boring-file-regexp-list nil))
        (helm :sources ,source
              :buffer "*helm projectile*"
-             :truncate-lines helm-projectile-truncate-lines
+             :truncate-lines ,truncate-lines-var
              :prompt (projectile-prepend-project-name ,prompt)))))
 
 (helm-projectile-command "switch-project" 'helm-source-projectile-projects "Switch to project: " t)
@@ -688,7 +689,7 @@ With a prefix ARG invalidates the cache first."
 (helm-projectile-command "find-file-in-known-projects" 'helm-source-projectile-files-in-all-projects-list "Find file in projects: " t)
 (helm-projectile-command "find-dir" helm-source-projectile-directories-and-dired-list "Find dir: ")
 (helm-projectile-command "recentf" 'helm-source-projectile-recentf-list "Recently visited file: ")
-(helm-projectile-command "switch-to-buffer" 'helm-source-projectile-buffers-list "Switch to buffer: ")
+(helm-projectile-command "switch-to-buffer" 'helm-source-projectile-buffers-list "Switch to buffer: " nil helm-buffers-truncate-lines)
 (helm-projectile-command "browse-dirty-projects" 'helm-source-projectile-dirty-projects "Select a project: " t)
 
 (defun helm-projectile--files-display-real (files root)
@@ -833,7 +834,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
      :default-directory default-directory
      :keymap helm-grep-map
      :history 'helm-grep-history
-     :truncate-lines helm-projectile-truncate-lines)))
+     :truncate-lines helm-grep-truncate-lines)))
 
 ;;;###autoload
 (defun helm-projectile-on ()

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -67,8 +67,8 @@
   "Truncate lines in helm projectile commands when non--nil.
 
 Some helm-projectile commands have similar behavior with existing
-Helms. In these cases their respective custom var for truncation
-of lines will be honored. E.g. `helm-buffers-truncate-lines'
+Helms.  In these cases their respective custom var for truncation
+of lines will be honored.  E.g. `helm-buffers-truncate-lines'
 dictates the truncation in `helm-projectile-switch-to-buffer'."
   :group 'helm-projectile
   :type 'boolean)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -665,7 +665,9 @@ COMMAND is a command name to be appended with \"helm-projectile\" prefix.
 SOURCE is a Helm source that should be Projectile specific.
 PROMPT is a string for displaying as a prompt.
 NOT-REQUIRE-ROOT specifies the command doesn't need to be used in a
-project root."
+project root.
+TRUNCATE-LINES-VAR is the symbol used dictate truncation of lines.
+Defaults is `helm-projectile-truncate-lines'."
   (unless truncate-lines-var (setq truncate-lines-var 'helm-projectile-truncate-lines))
   `(defun ,(intern (concat "helm-projectile-" command)) (&optional arg)
      "Use projectile with Helm for finding files in project


### PR DESCRIPTION
Line truncation of helm buffers should be customize-able, IMHO. This simple straight-on approach uses a single variable for all helm commands in this package. It could probably be more advanced and I picture two alternative implementations:
1. A new (custom) variable for each helm command. This involves black magic in the `helm-projectile-command` macro which is way beyond my elisp knowledge.
2. A custom list of commands that should have truncation with a default fall-back (like the one implemented in this PR).