### PR TITLE
Allow projectile-find-file-hook to be executed on a buffer which is not yet in projectile-mode

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -456,12 +456,6 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                                             (list candidate))))
           (rename-buffer dired-buffer-name))))))
 
-(advice-add 'helm-find-file-or-marked :after
-            (lambda (orig-fun &rest args)
-              "Run `projectile-find-file-hook' if using projectile."
-              (when (and projectile-mode (projectile-project-p))
-                (run-hooks 'projectile-find-file-hook))))
-
 (defvar helm-projectile-find-file-map
   (let ((map (copy-keymap helm-find-files-map)))
     (helm-projectile-define-key map
@@ -698,6 +692,14 @@ With a prefix ARG invalidates the cache first."
 (helm-projectile-command "recentf" 'helm-source-projectile-recentf-list "Recently visited file: ")
 (helm-projectile-command "switch-to-buffer" 'helm-source-projectile-buffers-list "Switch to buffer: " nil helm-buffers-truncate-lines)
 (helm-projectile-command "browse-dirty-projects" 'helm-source-projectile-dirty-projects "Select a project: " t)
+
+;; Make `helm-projectile-find-file' call the hooks in `projectile-find-file-hook'
+;; just as the regular function `projectile-find-file' does.
+(advice-add 'helm-projectile-find-file :after
+            (lambda (&optional arg) (run-hooks 'projectile-find-file-hook)))
+;; Same for `helm-projectile-find-dir' and `projectile-find-dir-hook'
+(advice-add 'helm-projectile-find-dir :after
+            (lambda (&optional arg) (run-hooks 'projectile-find-dir-hook)))
 
 (defun helm-projectile--files-display-real (files root)
   "Create (DISPLAY . REAL) pairs with FILES and ROOT.


### PR DESCRIPTION
The current code prevent the hooks to be called if the current buffer minor mode is not already `projectile-mode`. This is a problem since I meant to implement a hook to switch the new opened buffer to projectile mode if it was opened by `[helm-]projectile-find-file` in the first place.

In addition there is currently an advice for `helm-projectile-find-file` to call its hooks but it is modifying an external package (`helm-find-file-or-marked`) which means that it can potentially have side effects outside `helm-projectile`.

So this pull request propose another means to achieve the same result: the advice is added to `helm-projectile-find-file` itself. As result the condition on the current buffer being already in `projectile-mode` is no longer needed and it keeps the call to the hooks internal to the `helm-projectile` package.

The pull request also removes the advice added to the global function `helm-find-file-or-marked` as it would make the hooks to be called twice.

Finally the pull request applies the same modification to `helm-projectile-find-dir` so that it calls its hooks.