### PR TITLE
Separate buffers for separate projects

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -687,7 +687,7 @@ With a prefix ARG invalidates the cache first."
            ;; for consistency, we should just let Projectile take care of ignored files
            (helm-boring-file-regexp-list nil))
        (helm :sources ,source
-             :buffer "*helm projectile*"
+             :buffer (concat "*helm projectile: " (projectile-project-name) "*")
              :truncate-lines ,truncate-lines-var
              :prompt (projectile-prepend-project-name ,prompt)))))
 


### PR DESCRIPTION
https://github.com/bbatsov/projectile/pull/1149 introduced
buffer-local caching of certain project variables, which in turn
has caused issues with other commands not working properly. One
example is https://github.com/bbatsov/projectile/pull/1151

When using `helm-projectile`, `helm-projectile-find-file` is broken
after switching buffers, because all helm commands are run in the
context of a global `helm-projectile` buffer, incorrect cache values
are return from functions like `(projectile-project-root)`

My particular issue has been that after switching to a new project, or
moving between windows, `helm-projectile-find-file` has opened helm
with a list of files from _the previous project._

I was able to fix this initially by adding
`(projectile-reset-cached-project-root)` into the
[`:candidates` for `helm-source-projectile-files-list`](https://github.com/bbatsov/helm-projectile/blob/0e9ba276b3fbc420b8cbdc1b99262ccd5c750db7/helm-projectile.el#L503)
but that would seem to break the point of the project caching that was
recently introduced.

By executing helm commands in a separate buffer for each project, we
are able to take advantage of performance boosts from buffer-local caches