### PR TITLE
[feat] use selected text as initial search string (helm-rg)

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -961,6 +961,10 @@ DIR is the project root, if not set then current directory is used"
 (defvar helm-rg-include-file-on-every-match-line)
 (declare-function helm-rg "helm-rg")
 
+(defun helm-projectile-rg--region-selection ()
+  (when (use-region-p)
+    (buffer-substring-no-properties (region-beginning) (region-end))))
+
 ;;;###autoload
 (defun helm-projectile-rg ()
   "Projectile version of `helm-rg'."
@@ -969,7 +973,7 @@ DIR is the project root, if not set then current directory is used"
       (if (projectile-project-p)
           (let ((helm-rg-prepend-file-name-line-at-top-of-matches nil)
                 (helm-rg-include-file-on-every-match-line t))
-            (helm-rg "" nil (list (projectile-project-root))))
+            (helm-rg (or (helm-projectile-rg--region-selection) "") nil (list (projectile-project-root))))
         (error "You're not in a project"))
     (when (yes-or-no-p "`helm-rg' is not installed. Install? ")
       (condition-case nil


### PR DESCRIPTION
Currently it is always an empty string. Calling `helm-rg` directly at
least uses the thing at point.
Using the current selection is also done by `helm-projectile-ag` so this
should be consistent with what is already there.