### PR TITLE
Recentf source returns nil instead of error when not in project

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -687,9 +687,10 @@ Meant to be added to `helm-cleanup-hook', from which it removes
 (defvar helm-source-projectile-recentf-list
   (helm-build-sync-source "Projectile recent files"
     :candidates (lambda ()
-                  (with-helm-current-buffer
-                    (helm-projectile--files-display-real (projectile-recentf-files)
-                                                         (projectile-project-root))))
+                  (when (projectile-project-p)
+                   (with-helm-current-buffer
+                     (helm-projectile--files-display-real (projectile-recentf-files)
+                                                          (projectile-project-root)))))
     :fuzzy-match helm-projectile-fuzzy-match
     :keymap helm-projectile-find-file-map
     :help-message 'helm-ff-help-message


### PR DESCRIPTION
This fixes a bug when trying to use `helm-source-projectile-recentf-list` as a source for helm. This uses the same fix introduced by 6e881c824a01251a866e5070980cb25ca5b0dc66 to fix #98 