### PR TITLE
Fix "Not in project" error from helm-source-projectile-files-list

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -546,21 +546,22 @@ Meant to be added to `helm-cleanup-hook', from which it removes
                                collect (cons display (expand-file-name display root))))))
     :filtered-candidate-transformer
     (lambda (files _source)
-      (with-helm-current-buffer
-        (let* ((root (projectile-project-root))
-               (file-at-root (file-relative-name (expand-file-name helm-pattern root))))
-          (if (or (string-empty-p helm-pattern)
-                  (assoc helm-pattern files))
-              files
-            (if (equal helm-pattern file-at-root)
-                (cl-acons (helm-ff-prefix-filename helm-pattern nil t)
-                          (expand-file-name helm-pattern)
-                          files)
-              (cl-pairlis (list (helm-ff-prefix-filename helm-pattern nil t)
-                                (helm-ff-prefix-filename file-at-root nil t))
-                          (list (expand-file-name helm-pattern)
-                                (expand-file-name helm-pattern root))
-                          files))))))
+      (when (projectile-project-p)
+        (with-helm-current-buffer
+          (let* ((root (projectile-project-root))
+                 (file-at-root (file-relative-name (expand-file-name helm-pattern root))))
+            (if (or (string-empty-p helm-pattern)
+                    (assoc helm-pattern files))
+                files
+              (if (equal helm-pattern file-at-root)
+                  (cl-acons (helm-ff-prefix-filename helm-pattern nil t)
+                            (expand-file-name helm-pattern)
+                            files)
+                (cl-pairlis (list (helm-ff-prefix-filename helm-pattern nil t)
+                                  (helm-ff-prefix-filename file-at-root nil t))
+                            (list (expand-file-name helm-pattern)
+                                  (expand-file-name helm-pattern root))
+                            files)))))))
     :fuzzy-match helm-projectile-fuzzy-match
     :keymap helm-projectile-find-file-map
     :help-message 'helm-ff-help-message


### PR DESCRIPTION
Also need to guard the call to projectile-project-root in
filtered-candidate-transformer, otherwise if this source is called outside a
project it errors out instead of just being empty.