### PR TITLE
Fix for change in project-get-other-files signature

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -791,7 +791,6 @@ Other file extensions can be customized with the variable `projectile-other-file
   (interactive "P")
   (let* ((project-root (projectile-project-root))
          (other-files (projectile-get-other-files (buffer-file-name)
-                                                  (projectile-current-project-files)
                                                   flex-matching)))
     (if other-files
         (if (= (length other-files) 1)


### PR DESCRIPTION
project-get-other-files now only takes two arguments. Change was in https://github.com/bbatsov/projectile/pull/1394