### PR TITLE
[GH-124] Remove "targets" for `helm-do-ag`

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -947,7 +947,7 @@ DIR is the project root, if not set then current directory is used"
                                      " "))
                  (helm-ag-base-command (concat helm-ag-base-command " " ignored " " options))
                  (current-prefix-arg nil))
-            (helm-do-ag (projectile-project-root) (car (projectile-parse-dirconfig-file))))
+            (helm-do-ag (projectile-project-root)))
         (error "You're not in a project"))
     (when (yes-or-no-p "`helm-ag' is not installed. Install? ")
       (condition-case nil


### PR DESCRIPTION
The intention here was to include directories prefixed with `+` in `.projectile`, but that's not what the `TARGETS` parameter is for in `helm-do-ag`. Instead, `TARGETS` restricts the search to only files / directories in `TARGETS`.