### PR TITLE
[GH-124] Properly set `helm-ag` targets

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -946,8 +946,9 @@ DIR is the project root, if not set then current directory is used"
                                      (append grep-find-ignored-files grep-find-ignored-directories (cadr (projectile-parse-dirconfig-file)))
                                      " "))
                  (helm-ag-base-command (concat helm-ag-base-command " " ignored " " options))
-                 (current-prefix-arg nil))
-            (helm-do-ag (projectile-project-root) (car (projectile-parse-dirconfig-file))))
+                 (current-prefix-arg nil)
+                 (keep-paths (projectile-normalise-paths (car (projectile-parse-dirconfig-file)))))
+            (helm-do-ag (projectile-project-root) (append (list (projectile-project-root)) keep-paths (projectile-paths-to-ensure))))
         (error "You're not in a project"))
     (when (yes-or-no-p "`helm-ag' is not installed. Install? ")
       (condition-case nil


### PR DESCRIPTION
Include paths to keep and ensure specified in `.projectile`.