### PR TITLE
Allow customization of grep commands.

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -925,7 +925,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
 (defun helm-projectile-grep (&optional dir)
   "Helm version of `projectile-grep'.
 DIR is the project root, if not set then current directory is used"
-  (interactive)
+  (interactive "D")
   (let ((project-root (or dir (projectile-project-root) (error "You're not in a project"))))
     (funcall 'run-with-timer 0.01 nil
              #'helm-projectile-grep-or-ack project-root nil)))
@@ -933,7 +933,7 @@ DIR is the project root, if not set then current directory is used"
 ;;;###autoload
 (defun helm-projectile-ack (&optional dir)
   "Helm version of projectile-ack."
-  (interactive)
+  (interactive "D")
   (let ((project-root (or dir (projectile-project-root) (error "You're not in a project"))))
     (let ((ack-ignored (mapconcat
                         'identity

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -708,6 +708,23 @@ Meant to be added to `helm-cleanup-hook', from which it removes
   '(helm-source-projectile-dired-files-list
     helm-source-projectile-directories-list))
 
+(defcustom helm-projectile-git-grep-command
+  "git --no-pager grep --no-color -n%c -e %p -- %f"
+  "Command to execute when performing `helm-grep' inside a projectile git project.
+See documentation of `helm-grep-default-command' for the format."
+  :type 'string
+  :group 'helm-projectile
+  )
+
+(defcustom helm-projectile-grep-command
+  "grep -a -r %e -n%cH -e %p %f ."
+  "Command to execute when performing `helm-grep' outside a projectile git project.
+See documentation of `helm-grep-default-command' for the format."
+  :type 'string
+  :group 'helm-projectile
+  )
+
+
 (defcustom helm-projectile-sources-list
   '(helm-source-projectile-buffers-list
     helm-source-projectile-files-list
@@ -852,8 +869,8 @@ If it is nil, or ack/ack-grep not found then use default grep command."
          (helm-grep-default-command (if use-ack-p
                                         (concat ack-executable " -H --no-group --no-color " ack-ignored-pattern " %p %f")
                                       (if (and projectile-use-git-grep (eq (projectile-project-vcs) 'git))
-                                          "git --no-pager grep --no-color -n%c -e %p -- %f"
-                                        "grep -a -r %e -n%cH -e %p %f .")))
+                                          helm-projectile-git-grep-command
+                                        helm-projectile-grep-command)))
          (helm-grep-default-recurse-command helm-grep-default-command))
 
     (setq helm-source-grep


### PR DESCRIPTION
This is especially useful in the case of the git grep command where it is often desirable to recurse into submodules with something like
```git --no-pager grep --recurse-submodules --no-color -n%c -e %p -- %f```

This fixes #134 