### PR TITLE
Add "ext:" to functions in external packages

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -50,7 +50,7 @@
 (require 'helm-files)
 
 (declare-function eshell "eshell")
-(declare-function helm-do-ag "helm-ag")
+(declare-function helm-do-ag "ext:helm-ag")
 (declare-function dired-get-filename "dired")
 (defvar helm-ag-base-command)
 
@@ -959,7 +959,7 @@ DIR is the project root, if not set then current directory is used"
 ;; Declare/define these to satisfy the byte compiler
 (defvar helm-rg-prepend-file-name-line-at-top-of-matches)
 (defvar helm-rg-include-file-on-every-match-line)
-(declare-function helm-rg "helm-rg")
+(declare-function helm-rg "ext:helm-rg")
 
 (defun helm-projectile-rg--region-selection ()
   (when helm-projectile-set-input-automatically


### PR DESCRIPTION
Per the documentation for declare-function, functions in external
packages should be prefaced with "ext:".


----

#