### PR TITLE
Fix interactive options.

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -925,7 +925,7 @@ If it is nil, or ack/ack-grep not found then use default grep command."
 (defun helm-projectile-grep (&optional dir)
   "Helm version of `projectile-grep'.
 DIR is the project root, if not set then current directory is used"
-  (interactive "D")
+  (interactive)
   (let ((project-root (or dir (projectile-project-root) (error "You're not in a project"))))
     (funcall 'run-with-timer 0.01 nil
              #'helm-projectile-grep-or-ack project-root nil)))
@@ -933,7 +933,7 @@ DIR is the project root, if not set then current directory is used"
 ;;;###autoload
 (defun helm-projectile-ack (&optional dir)
   "Helm version of projectile-ack."
-  (interactive "D")
+  (interactive)
   (let ((project-root (or dir (projectile-project-root) (error "You're not in a project"))))
     (let ((ack-ignored (mapconcat
                         'identity


### PR DESCRIPTION
The "D" interactive option sets the default directory for the function, which I don't think you want to do here. The projectile-project-root isn't found in this case. 

Instead of this patch, you can also just revert commit fe33a15.

