### PR TITLE
Use helm-projectile in switch to project action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 ### Changes
+* [#146](https://github.com/bbatsov/helm-projectile/pull/146): Use helm-projectile interface after switching to a project in helm-projectile-switch-project
 
 ### Bugs fixed
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -209,8 +209,8 @@ It is there because Helm requires it."
 (defcustom helm-source-projectile-projects-actions
   (helm-make-actions
    "Switch to project" (lambda (project)
-                         (let ((projectile-completion-system 'helm))
-                           (projectile-switch-project-by-name project)))
+                         (let ((default-directory (expand-file-name project)))
+                           (helm-projectile)))
    "Open Dired in project's directory `C-d'" #'dired
    "Open project root in vc-dir or magit `M-g'" #'helm-projectile-vc
    "Switch to Eshell `M-e'" #'helm-projectile-switch-to-eshell


### PR DESCRIPTION
Use `helm-projectile` interface immediately after switching to a project with `helm-projectile-switch-project`.

This is a very small change, in addition to the file listing shown before, it gives the user their project buffers and recentf as sources after switching projects. It's the same interface but a little more convenient.

Closes #142

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

:question: The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)