### PR TITLE
Change apt-get to apt in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ action.
 
 ### Debian and Ubuntu
 
-Users of Debian 9 or later or Ubuntu 16.04 or later may `apt-get
+Users of Debian 9 or later or Ubuntu 16.04 or later may `apt
 install elpa-helm-projectile`.
 
 ## Usage


### PR DESCRIPTION
> apt is a high-level command-line interface for better interactive usage

according to https://salsa.debian.org/apt-team/apt the README.md file of apt-get and apt.
