### PR TITLE
Fix type for helm-projectile-sources-list variable

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -731,7 +731,7 @@ See documentation of `helm-grep-default-command' for the format."
     helm-source-projectile-files-list
     helm-source-projectile-projects)
   "Default sources for `helm-projectile'."
-  :type 'list
+  :type '(repeat symbol)
   :group 'helm-projectile)
 
 (defmacro helm-projectile-command (command source prompt &optional not-require-root truncate-lines-var)


### PR DESCRIPTION
According to the
https://www.gnu.org/software/emacs/manual/html_node/elisp/Composite-Types.html
`list` is a composite type and should be used when the number of
elements and its types are known. For `helm-projectile-sources-list` the
better option would be `(repeat symbol)`.

emacs-29 introduces `setopt` macro to set customizable variables, it
verifies variable type according to `:type` annotation and throw an
error if type mismatches.

**Replace this placeholder text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
