### PR TITLE
Make helm-projectile-ag provide a default search input like helm-proj…

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -967,8 +967,12 @@ DIR is the project root, if not set then current directory is used"
                                      (append grep-find-ignored-files grep-find-ignored-directories (cadr (projectile-parse-dirconfig-file)))
                                      " "))
                  (helm-ag-base-command (concat helm-ag-base-command " " ignored " " options))
-                 (current-prefix-arg nil))
-            (helm-do-ag (projectile-project-root) (car (projectile-parse-dirconfig-file))))
+                 (current-prefix-arg nil)
+                 (default-input (when helm-projectile-set-input-automatically
+                                  (if (region-active-p)
+                                      (buffer-substring-no-properties (region-beginning) (region-end))
+                                    (thing-at-point 'symbol)))))
+            (helm-do-ag (projectile-project-root) (car (projectile-parse-dirconfig-file)) default-input))
         (error "You're not in a project"))
     (when (yes-or-no-p "`helm-ag' is not installed. Install? ")
       (condition-case nil


### PR DESCRIPTION
…ectile-grep.

When using `helm-projectile-grep` the search term will automatically be populated with the symbol at point, or the selected region. These changes make `helm-projectile-ag` do the same thing.

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md) (Not sure this exists??)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
