### PR TITLE
Respect helm-buffer-max-length if it's nil

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -670,12 +670,12 @@ Meant to be added to `helm-cleanup-hook', from which it removes
                                                                (symbol-name major-mode)))
                                             into len-mode
                                             finally return (cons len-buf len-mode))))
-                       (unless helm-buffer-max-length
-                         (setq helm-buffer-max-length (car result)))
-                       (unless helm-buffer-max-len-mode
+                       (unless (default-value 'helm-buffer-max-length)
+                         (helm-set-local-variable 'helm-buffer-max-length (car result)))
+                       (unless (default-value 'helm-buffer-max-len-mode)
                          ;; If a new buffer is longer that this value
                          ;; this value will be updated
-                         (setq helm-buffer-max-len-mode (cdr result))))))
+                         (helm-set-local-variable 'helm-buffer-max-len-mode (cdr result))))))
    (candidates :initform helm-projectile-buffers-list-cache)
    (matchplugin :initform nil)
    (match :initform 'helm-buffers-match-function)


### PR DESCRIPTION
Don't overwrite helm-buffer-max-length when it's nil, because nil indicates that we should use the max length of the longest file every time.

This code is now the same as what helm-buffers does: https://github.com/emacs-helm/helm/blob/8ed0ab7762ad76da02d8832aa18d03e1288ea6d5/helm-buffers.el#L300

You can reproduce the issue by setting helm-buffer-max-length to nil, opening helm projectile, and then opening helm buffer and seeing that the files in the buffer may be getting cut off if the longest file in helm projectile is shorter.

This is just a drive-by PR and I've fixed the problem on my end, so I haven't checked the boxes below. If it's too much extra work on your end, no need to merge. Thanks!!

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
