### PR TITLE
Correctly remove current buffer from helm-source-projectile-buffers-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs fixed
 
+* [#176](https://github.com/bbatsov/helm-projectile/pull/178): Correctly remove current buffer from `helm-source-projectile-buffers-list`.
 * [#151](https://github.com/bbatsov/helm-projectile/pull/157): Teach `helm-projectile-rg` to respect ignored files and directories.
 * [#151](https://github.com/bbatsov/helm-projectile/issues/151): Rename `helm-projectile-switch-to-eshell` -> `helm-projectile-switch-to-shell`.
 * [#143](https://github.com/bbatsov/helm-projectile/issues/143): Fix rg command for helm-ag arity.

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -664,7 +664,7 @@ Meant to be added to `helm-cleanup-hook', from which it removes
   ((init :initform (lambda ()
                      ;; Issue #51 Create the list before `helm-buffer' creation.
                      (setq helm-projectile-buffers-list-cache
-                           (ignore-errors (cdr (projectile-project-buffer-names))))
+                           (ignore-errors (remove (buffer-name) (projectile-project-buffer-names))))
                      (let ((result (cl-loop for b in helm-projectile-buffers-list-cache
                                             maximize (length b) into len-buf
                                             maximize (length (with-current-buffer b


### PR DESCRIPTION
Sometimes, the first element in `projectile-project-buffer-names` is not actually a current buffer so just replace `(cdr ...` with `(remove (buffer-name) ...`.

Fixes #176

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
