### PR TITLE
Introduce helm-projectile-ignore-strategy, closes #58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Improve `helm-source-proctile-project-list` by also inheriting the `helm-type-file` class to benefit of it's functionality
   such as candidate transformer or file cache.
+* [#180](https://github.com/bbatsov/helm-projectile/pull/180): Introduce `helm-projectile-ignore-strategy` defcustom.
 
 ### Changes
 


### PR DESCRIPTION
New defcustom that when set to 'projectile', will compute ignores and explicitely add additionally command line arguments to the search tool. Note that this might override search tool specific behaviors (for instance ag would not use VCS ignore files).

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)
