### PR TITLE
Deep copy list of known projects to avoid helm adding faces

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -223,7 +223,9 @@ It is there because Helm requires it."
   :type '(alist :key-type string :value-type function))
 
 (defclass helm-projectile-projects-source (helm-source-sync helm-type-file)
-  ((candidates :initform (lambda () (with-helm-current-buffer (projectile-known-projects))))
+  ((candidates :initform (lambda () (with-helm-current-buffer
+                                      (mapcar #'copy-sequence
+                                              (projectile-known-projects)))))
    (fuzzy-match :initform 'helm-projectile-fuzzy-match)
    (keymap :initform 'helm-projectile-projects-map)
    (mode-line :initform 'helm-read-file-name-mode-line-string)


### PR DESCRIPTION
I am not sure if this is the correct way to fix, yet this workaround seems to
work in my case. I had very similar observations as others claimed in #185 when
trying to debug this issue. Namely, right after executing
`helm-projectile-swithc-project` I observed that `projectile-known-projects`
had names changed with fontification.

Fixes #185

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)