### PR TITLE
Fix helm-projectile-projects-source slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#188](https://github.com/bbatsov/helm-projectile/pull/178): Fix helm-projectile-projects-source slots
+
 ## 1.1.0 (2025-02-14)
 
 ### New features

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -244,10 +244,17 @@ help message slots to file specific ones.  Override these slots
 to be specific to `helm-projectile-projects-source'."
   (setf (slot-value source 'action) 'helm-source-projectile-projects-actions)
   (setf (slot-value source 'keymap) helm-projectile-projects-map)
-  (setf (slot-value source 'persistent-action) nil)
-  (setf (slot-value source 'persistent-help) "DoNothing")
-  (setf (slot-value source 'header-line) (helm-source--header-line source))
-  (setf (slot-value source 'mode-line) (list "Project(s)" helm-mode-line-string)))
+  ;; Use `ignore' as a persistent action, to actually keep `helm' session
+  ;; when `helm-execute-persistent-action' is executed.
+  (setf (slot-value source 'persistent-action) #'ignore)
+  (let ((persistent-help "Do Nothing"))
+    (setf (slot-value source 'persistent-help) persistent-help)
+    (setf (slot-value source 'header-line)
+          (helm-source--persistent-help-string
+           persistent-help
+           source)))
+  (setf (slot-value source 'mode-line)
+        (list "Project(s)" helm-mode-line-string)))
 
 (defvar helm-source-projectile-projects
   (helm-make-source "Projectile projects" 'helm-projectile-projects-source))

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -237,7 +237,12 @@ It is there because Helm requires it."
   "Helm source for known projectile projects.")
 
 (cl-defmethod helm--setup-source :after ((source helm-projectile-projects-source))
-  (setf (slot-value source 'action) 'helm-source-projectile-projects-actions))
+  (setf (slot-value source 'action) 'helm-source-projectile-projects-actions)
+  (setf (slot-value source 'keymap) helm-projectile-projects-map)
+  (setf (slot-value source 'persistent-action) nil)
+  (setf (slot-value source 'persistent-help) "DoNothing")
+  (setf (slot-value source 'header-line) (helm-source--header-line source))
+  (setf (slot-value source 'mode-line) (list "Project(s)" helm-mode-line-string)))
 
 (defvar helm-source-projectile-projects
   (helm-make-source "Projectile projects" 'helm-projectile-projects-source))

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -237,6 +237,11 @@ It is there because Helm requires it."
   "Helm source for known projectile projects.")
 
 (cl-defmethod helm--setup-source :after ((source helm-projectile-projects-source))
+  "Make SOURCE specific to project switching.
+The `helm-projectile-projects-source` inherits from
+`helm-type-file` (which see), which sets up actions, keymap, and
+help message slots to file specific ones.  Override these slots
+to be specific to `helm-projectile-projects-source'."
   (setf (slot-value source 'action) 'helm-source-projectile-projects-actions)
   (setf (slot-value source 'keymap) helm-projectile-projects-map)
   (setf (slot-value source 'persistent-action) nil)


### PR DESCRIPTION
Update slots specific to `helm-projectile-projects-source` that are overwritten
by `helm-type-files`. The goal is to get back functionality, that has been
changed with #181.

I think that the biggest miss is the lack of `helm-projectile-projects-map`
resulting in inability to instantaneously run things like `magit-status` for
a project.

I also have taken a liberty and updated modeline to display, in my opinion,
more suitable "Project(s)" (instead of "File(s)").


Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!