### PR TITLE
Fix duplicated --ignore arguments in helm-projectile-ag

### DIFF
--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -880,11 +880,11 @@ When set to `search-tool', the above does not happen."
 
 (defun helm-projectile--ignored-files ()
   "Compute ignored files."
-  (cl-union (projectile-ignored-files-rel) grep-find-ignored-files))
+  (cl-union (projectile-ignored-files-rel) grep-find-ignored-files :test #'string-equal))
 
 (defun helm-projectile--ignored-directories ()
   "Compute ignored directories."
-  (cl-union (projectile-ignored-directories-rel) grep-find-ignored-directories))
+  (cl-union (projectile-ignored-directories-rel) grep-find-ignored-directories :test #'string-equal))
 
 (defcustom helm-projectile-grep-or-ack-actions
   '("Find file" helm-grep-action


### PR DESCRIPTION
### Problem

When `helm-projectile-ag` is executed multiple times in the same Emacs session, the constructed ag command may accumulate **duplicate --ignore arguments**. This is because `helm-projectile--ignored-files` and `helm-projectile--ignored-directories` use `cl-union` without specifying a comparison function, causing logically identical strings to be treated as different if not eq.

This results in unnecessary command-line length and potentially affects performance or correctness.