### PR TITLE
Fix `helm-rg--extra-args` failing to provide valid globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 ### Bugs fixed
-
+* [#189](https://github.com/bbatsov/helm-projectile/pull/192): Fix helm-projectile-rg specifying incorrect extra args.
 * [#188](https://github.com/bbatsov/helm-projectile/pull/178): Fix helm-projectile-projects-source slots
 
 ## 1.1.0 (2025-02-14)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1059,11 +1059,6 @@ OPTIONS explicit command line arguments to ag"
         (buffer-substring-no-properties (region-beginning) (region-end))
       (helm-rg--get-thing-at-pt))))
 
-(defun glob-quote (string)
-  "Quote the special glob characters: *, ?, [, and ].
-STRING the string in which to escape special characters."
-  (replace-regexp-in-string "[]*?[]" "\\\\\\&" string))
-
 ;;;###autoload
 (defun helm-projectile-rg ()
   "Projectile version of `helm-rg'."
@@ -1074,16 +1069,18 @@ STRING the string in which to escape special characters."
                  (helm-rg-include-file-on-every-match-line t)
                  (default-directory (projectile-project-root)))
             (when (helm-projectile--projectile-ignore-strategy)
-              (setq helm-rg--extra-args
-                    (mapconcat
-                     'identity
-                     (cl-union (mapcan (lambda (path)
-                                         (list "--glob" (concat "!" (glob-quote path))))
-                                       (helm-projectile--ignored-files))
-                               (mapcan (lambda (path)
-                                         (list "--glob" (concat "!" (glob-quote path) "/**")))
-                                       (mapcar 'directory-file-name (helm-projectile--ignored-directories))))
-                     " ")))
+              (setq helm-rg--extra-args 
+                (mapcan (lambda (path) (list "--glob" path))
+                  (cl-union (mapcar (lambda (path)
+                                      (concat "!" path))
+                              (helm-projectile--ignored-files))
+                    (mapcar (lambda (path)
+                              (concat "!" path "/**"))
+                      (mapcar 'directory-file-name (helm-projectile--ignored-directories)))
+                    )
+                  )
+                )
+              )
             (helm-rg (helm-projectile-rg--region-selection)
                      nil))
         (error "You're not in a project"))


### PR DESCRIPTION
closes #189 
a few things were wrong here: 
1. Previously the code setting `helm-rg--extra-args` was de-duping the "--glob" literal resulting in a non-parsable set of args.
2. The `grep-find-ignored-files` often contains string like `*.ext` which would unfortunately get escaped by the `glob-quote` utility.
3. The previous code would concat these together as a single string, which helm-rg doesn't expect

This patch addresses both of these.
-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md) doesnt exist :/
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
