### PR TITLE
Respect helm-buffer-max-length if it's nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#173](https://github.com/bbatsov/helm-projectile/pull/173), [#194](https://github.com/bbatsov/helm-projectile/pull/194): Respect helm-buffer-max-length if it's nil
+
 ### Bugs fixed
 
 * [#188](https://github.com/bbatsov/helm-projectile/pull/178): Fix helm-projectile-projects-source slots

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -699,12 +699,12 @@ Meant to be added to `helm-cleanup-hook', from which it removes
                                                                (symbol-name major-mode)))
                                             into len-mode
                                             finally return (cons len-buf len-mode))))
-                       (unless helm-buffer-max-length
-                         (setq helm-buffer-max-length (car result)))
-                       (unless helm-buffer-max-len-mode
+                       (unless (default-value 'helm-buffer-max-length)
+                         (helm-set-local-variable 'helm-buffer-max-length (car result)))
+                       (unless (default-value 'helm-buffer-max-len-mode)
                          ;; If a new buffer is longer that this value
                          ;; this value will be updated
-                         (setq helm-buffer-max-len-mode (cdr result))))))
+                         (helm-set-local-variable 'helm-buffer-max-len-mode (cdr result))))))
    (candidates :initform 'helm-projectile-buffers-list-cache)
    (matchplugin :initform nil)
    (match :initform 'helm-buffers-match-function)


### PR DESCRIPTION
-----------------
N.B. This work is a re-implementation of #173 by @samertm from a few years
back. I can confirm that `helm-projectile` still suffers from the condition,
and that the fix works. Unfortunately, I cannot push to the original branch,
hence the new PR.

Closes: #173

Below, please find text from the original PR.

-----------------

Don't overwrite helm-buffer-max-length when it's nil, because nil
indicates that we should use the max length of the longest file every
time.

This code is now the same as what helm-buffers does:
https://github.com/emacs-helm/helm/blob/8ed0ab7762ad76da02d8832aa18d03e1288ea6d5/helm-buffers.el#L300

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [ ] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

Thanks!