### PR TITLE
Restore compatibility with current Projectile + add tests/CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    paths-ignore: ['**.md', '**.adoc']
+  pull_request:
+    paths-ignore: ['**.md', '**.adoc']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # Run inside the prebuilt silex/emacs images (Eldev baked in).  Eldev pulls
+    # the project's dependencies (helm, projectile) and buttercup from the
+    # package archives.  The matrix `snapshot' label maps to the image's
+    # `master' tag.
+    container: silex/emacs:${{ matrix.emacs_version == 'snapshot' && 'master' || matrix.emacs_version }}-ci-eldev
+    continue-on-error: ${{matrix.emacs_version == 'snapshot'}}
+
+    strategy:
+      matrix:
+        # Earliest supported + latest in each stable branch + snapshot.
+        emacs_version: ['27.2', '28.2', '29.4', '30.2', 'snapshot']
+
+    steps:
+    - name: Check out the source code
+      uses: actions/checkout@v6
+
+    - name: Test the project
+      run: |
+        eldev -p -dtT test
+        eldev -dtT compile --warnings-as-errors

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.eldev/
+/Eldev-local
+*.elc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Restore compatibility with Projectile's `master`, which removed several commands helm-projectile relied on:
+  * Drop the Helm commander bindings. Projectile removed its single-key commander (`def-projectile-commander-method` / `projectile-commander-bindings`) in favor of the `projectile-dispatch` transient menu, so `C-c p m` now opens that menu. Without this change, enabling `helm-projectile` errored against current Projectile.
+  * Remove `helm-projectile-browse-dirty-projects`, mirroring Projectile dropping `projectile-browse-dirty-projects` (and the slow `vc-dir`-scraping helper it called).
+* Require Emacs 27.1+, matching Projectile's own minimum.
+
+### Internal
+
+* Add a Buttercup test suite and a GitHub Actions CI workflow (running inside the `silex/emacs` Docker images across Emacs 27.2-30.2 and snapshot).
+
 ## 1.4.0 (2025-09-02)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   * Remove `helm-projectile-browse-dirty-projects`, mirroring Projectile dropping `projectile-browse-dirty-projects` (and the slow `vc-dir`-scraping helper it called).
 * Require Emacs 27.1+, matching Projectile's own minimum.
 
+### Bugs fixed
+
+* Fix loading/byte-compilation on Emacs 27 and 28: the `helm-projectile-define-key` helper used `while-let`, which only exists on Emacs 29.1+, so the package failed to load on older Emacsen despite declaring support for them. Replaced with a portable loop.
+* Silence an obsolete bare `any` form in an `rx` expression (it now warns on recent Emacs); use `nonl`, preserving the original meaning.
+
 ### Internal
 
 * Add a Buttercup test suite and a GitHub Actions CI workflow (running inside the `silex/emacs` Docker images across Emacs 27.2-30.2 and snapshot).

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,12 @@
+; -*- mode: emacs-lisp; lexical-binding: t -*-
+
+(eldev-use-package-archive 'gnu-elpa)
+(eldev-use-package-archive 'nongnu-elpa)
+(eldev-use-package-archive 'melpa)
+
+;; The test suite lives in `test/' and shares a small helper module that every
+;; suite `require's, so put that directory on the load path when running tests.
+(eldev-add-loading-roots 'test "test")
+
+;; Buttercup is the test framework.
+(eldev-add-extra-dependencies 'test 'buttercup)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -8,7 +8,7 @@
 ;; Created: 2011-31-07
 ;; Keywords: project, convenience
 ;; Version: 1.4.0
-;; Package-Requires: ((emacs "26.1") (helm "3.0") (projectile "2.9"))
+;; Package-Requires: ((emacs "27.1") (helm "3.0") (projectile "2.9"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -334,70 +334,6 @@ to be specific to `helm-projectile-projects-source'."
         (helm-projectile-hack-actions
          helm-source-projectile-projects-actions
          '(helm-projectile-switch-project-by-name-other-frame . :make-first))))
-
-(defvar helm-projectile-dirty-projects-map
-  (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map helm-map)
-    (helm-projectile-define-key map
-      (kbd "C-d") #'dired
-      (kbd "M-o") #'helm-projectile-switch-project-by-name
-      (kbd "C-c o") #'helm-projectile-switch-project-by-name-other-window
-      (kbd "C-c C-o") #'helm-projectile-switch-project-by-name-other-frame
-      (kbd "M-e") #'helm-projectile-switch-to-shell
-      (kbd "C-s") #'helm-projectile-grep
-      (kbd "M-c") #'helm-projectile-compile-project
-      (kbd "M-t") #'helm-projectile-test-project
-      (kbd "M-r") #'helm-projectile-run-project
-      (kbd "M-D") #'helm-projectile-remove-known-project
-      (kbd "C-S-a") #'helm-projectile--switch-project-and-ag-action
-      (kbd "C-S-r") #'helm-projectile--switch-project-and-rg-action)
-    map)
-  "Mapping for dirty projectile projects.")
-
-(defvar helm-source-projectile-dirty-projects
-  (helm-build-sync-source "Projectile dirty projects"
-    :candidates (lambda () (with-helm-current-buffer (helm-projectile-get-dirty-projects)))
-    :fuzzy-match helm-projectile-fuzzy-match
-    :keymap helm-projectile-dirty-projects-map
-    :mode-line helm-read-file-name-mode-line-string
-    :action '(("Open project root in vc-dir or magit" . helm-projectile-vc)
-              ("Switch to project `M-o'" . helm-projectile-switch-project-by-name)
-              ("Switch to project other window `C-c o'" . helm-projectile-switch-project-by-name-other-window)
-              ("Switch to project other frame `C-c C-o'" . helm-projectile-switch-project-by-name-other-frame)
-              ("Open Dired in project's directory `C-d'" . dired)
-              ("Switch to Eshell `M-e'" . helm-projectile-switch-to-shell)
-              ("Grep in projects `C-s'" . helm-projectile-grep)
-              ("Compile project `M-c'. With C-u, new compile command"
-               . helm-projectile-compile-project)
-              ("Silver searcher (ag) in project `C-S-a'" . helm-projectile--switch-project-and-ag-action)
-              ("Ripgrep (rg) in project `C-S-r'" . helm-projectile--switch-project-and-rg-action)))
-    "Helm source for dirty version controlled projectile projects.")
-
-(defun helm-projectile-get-dirty-projects ()
-  "Return dirty version controlled known projects.
-The value is returned as an alist to have a nice display in Helm."
-  (message "Checking for dirty known projects...")
-  (let* ((status (projectile-check-vcs-status-of-known-projects))
-         (proj-dir (cl-loop for stat in status
-                            collect (car stat)))
-         (status-display (cl-loop for stat in status collect
-                                  (propertize (format "[%s]"
-                                                      (mapconcat 'identity
-                                                                 (car (cdr stat)) ", "))
-                                              'face 'helm-match)))
-         (max-status-display-length (cl-loop for sd in status-display
-                                             maximize (length sd)))
-         (status-display (cl-loop for sd in status-display collect
-                                  (format "%s%s    "
-                                          sd
-                                          (make-string
-                                           (- max-status-display-length (length sd)) ? ))))
-         (full-display (cl-mapcar 'concat
-                                  status-display
-                                  (mapcar (lambda (dir)
-                                            (propertize dir 'face 'helm-ff-directory))
-                                          proj-dir))))
-    (cl-pairlis full-display proj-dir)))
 
 (define-key helm-etags-map (kbd "C-c p f")
   (lambda ()
@@ -1125,9 +1061,6 @@ With a prefix ARG invalidates the cache first."
                          'helm-source-projectile-buffers-other-frame-list
                          "Switch to buffer (other frame): " nil helm-buffers-truncate-lines)
 
-;;;###autoload(autoload 'helm-projectile-browse-dirty-projects "helm-projectile" nil t)
-(helm-projectile-command "browse-dirty-projects" 'helm-source-projectile-dirty-projects "Select a project: " t)
-
 (defun helm-projectile--files-display-real (files root)
   "Create (DISPLAY . REAL) pairs with FILES and ROOT.
 
@@ -1446,7 +1379,7 @@ prefix argument then ask for FILES."
 
 ;;;###autoload
 (defun helm-projectile-ack (&optional dir types)
-  "Helm version of `projectile-ack'.
+  "Run an ack search in the current project with Helm.
 DIR directory where to search, if not set then current project root is
 used.  TYPES is a list of types to include in search.  When called with
 a prefix argument, then ask for TYPES."
@@ -1673,44 +1606,6 @@ package `helm-rg'."
                  (format "Directory %s is not in any project!" directory)
                (format "Not a directory %s" directory))))))
 
-(defun helm-projectile-commander-bindings ()
-  "Define Helm versions of Projectile commands in `projectile-commander'."
-  (def-projectile-commander-method ?a
-    "Run ack on project."
-    (call-interactively 'helm-projectile-ack))
-
-  (def-projectile-commander-method ?A
-    "Find ag on project."
-    (call-interactively 'helm-projectile-ag))
-
-  (def-projectile-commander-method ?f
-    "Find file in project."
-    (helm-projectile-find-file))
-
-  (def-projectile-commander-method ?b
-    "Switch to project buffer."
-    (helm-projectile-switch-to-buffer))
-
-  (def-projectile-commander-method ?d
-    "Find directory in project."
-    (helm-projectile-find-dir))
-
-  (def-projectile-commander-method ?g
-    "Run grep on project."
-    (helm-projectile-grep))
-
-  (def-projectile-commander-method ?s
-    "Switch project."
-    (helm-projectile-switch-project))
-
-  (def-projectile-commander-method ?e
-    "Find recently visited file in project."
-    (helm-projectile-recentf))
-
-  (def-projectile-commander-method ?V
-    "Find dirty projects."
-    (helm-projectile-browse-dirty-projects)))
-
 ;;;###autoload
 (defun helm-projectile-toggle (toggle)
   "Toggle Helm version of Projectile commands.
@@ -1752,11 +1647,8 @@ off."
         (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-window] #'helm-projectile-switch-to-buffer-other-window)
         (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-frame] #'helm-projectile-switch-to-buffer-other-frame)
         (define-key projectile-mode-map [remap projectile-grep] #'helm-projectile-grep)
-        (define-key projectile-mode-map [remap projectile-ack] #'helm-projectile-ack)
         (define-key projectile-mode-map [remap projectile-ag] #'helm-projectile-ag)
-        (define-key projectile-mode-map [remap projectile-ripgrep] #'helm-projectile-rg)
-        (define-key projectile-mode-map [remap projectile-browse-dirty-projects] #'helm-projectile-browse-dirty-projects)
-        (helm-projectile-commander-bindings))
+        (define-key projectile-mode-map [remap projectile-ripgrep] #'helm-projectile-rg))
     (progn
       (when (eq projectile-switch-project-action #'helm-projectile-find-file)
         (setq projectile-switch-project-action #'projectile-find-file))
@@ -1786,9 +1678,7 @@ off."
       (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-frame] nil)
       (define-key projectile-mode-map [remap projectile-grep] nil)
       (define-key projectile-mode-map [remap projectile-ag] nil)
-      (define-key projectile-mode-map [remap projectile-ripgrep] nil)
-      (define-key projectile-mode-map [remap projectile-browse-dirty-projects] nil)
-      (projectile-commander-bindings))))
+      (define-key projectile-mode-map [remap projectile-ripgrep] nil))))
 
 ;;;###autoload
 (defun helm-projectile (&optional arg)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -104,14 +104,17 @@ BINDINS is a list in a form of (KEY1 DEF1 KEY2 DEF2 ...)."
             (= 1 (% 2 (length bindings))))
     (error "Expected BINDINGS to be KEY1 DEF1 KEY2 DEF2 ... "))
   (let ((ret '(progn)))
-    (while-let ((key (car bindings))
-                (def (cadr bindings)))
-      (push
-       `(define-key ,keymap ,key
-                    (lambda ()
-                      (interactive)
-                      (helm-exit-and-execute-action ,def)))
-       ret)
+    ;; A plain `while' (rather than `while-let') keeps this macro usable on
+    ;; Emacs < 29.1; the length check above guarantees BINDINGS comes in pairs.
+    (while bindings
+      (let ((key (car bindings))
+            (def (cadr bindings)))
+        (push
+         `(define-key ,keymap ,key
+                      (lambda ()
+                        (interactive)
+                        (helm-exit-and-execute-action ,def)))
+         ret))
       (setq bindings (cddr bindings)))
     (reverse ret)))
 
@@ -1374,7 +1377,7 @@ prefix argument then ask for FILES."
                               ".*")
     (replace-regexp-in-string (rx (or string-start (not "[")) "[!") ;; [!...] -> [^...], but don't change [[!]
                               "[^")
-    (replace-regexp-in-string (rx (group (one-or-more any))) ;; Wrap everything in ^...$
+    (replace-regexp-in-string (rx (group (one-or-more nonl))) ;; Wrap everything in ^...$
                               "^\\1$")))
 
 ;;;###autoload

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -1,0 +1,79 @@
+;;; helm-projectile-test.el --- Tests for helm-projectile -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Tests for helm-projectile.
+
+;;; Code:
+
+(require 'helm-projectile)
+(require 'buttercup)
+
+(describe "helm-projectile package"
+  (it "defines its core entry-point commands"
+    (expect (commandp 'helm-projectile) :to-be-truthy)
+    (expect (commandp 'helm-projectile-find-file) :to-be-truthy)
+    (expect (commandp 'helm-projectile-switch-project) :to-be-truthy)
+    (expect (commandp 'helm-projectile-switch-to-buffer) :to-be-truthy)))
+
+(describe "helm-projectile-toggle"
+  ;; This is the regression guard for helm-projectile referencing Projectile
+  ;; internals that no longer exist (the commander macro/bindings were the
+  ;; breakage that prompted this suite).  Toggling must not error and must
+  ;; (un)install the command remaps on `projectile-mode-map'.
+  (after-each
+    ;; Always leave a clean slate regardless of what the example did.
+    (helm-projectile-toggle 0))
+
+  (it "enables without error and remaps core commands to their Helm versions"
+    (expect (helm-projectile-toggle 1) :not :to-throw)
+    (expect (lookup-key projectile-mode-map [remap projectile-find-file])
+            :to-be 'helm-projectile-find-file)
+    (expect (lookup-key projectile-mode-map [remap projectile-switch-to-buffer])
+            :to-be 'helm-projectile-switch-to-buffer)
+    (expect (lookup-key projectile-mode-map [remap projectile-grep])
+            :to-be 'helm-projectile-grep))
+
+  (it "disables without error and clears the remaps"
+    (helm-projectile-toggle 1)
+    (expect (helm-projectile-toggle 0) :not :to-throw)
+    (expect (lookup-key projectile-mode-map [remap projectile-find-file])
+            :to-be nil)))
+
+(describe "helm-projectile--files-display-real"
+  (it "maps each file to its absolute path under the project root"
+    ;; The display (car) is formatted by Helm and may be propertized, so we
+    ;; only assert on the real (cdr) part, which is the absolute path.
+    (let ((result (helm-projectile--files-display-real
+                   '("a.el" "src/b.el") "/proj/")))
+      (expect (mapcar #'cdr result)
+              :to-equal '("/proj/a.el" "/proj/src/b.el")))))
+
+(describe "removed features"
+  ;; Mirrors Projectile dropping its single-key commander and the
+  ;; browse-dirty-projects command; helm-projectile must not resurrect them.
+  (it "no longer defines the dirty-projects command"
+    (expect (fboundp 'helm-projectile-browse-dirty-projects) :not :to-be-truthy))
+  (it "no longer defines the commander bindings helper"
+    (expect (fboundp 'helm-projectile-commander-bindings) :not :to-be-truthy)))
+
+(provide 'helm-projectile-test)
+
+;;; helm-projectile-test.el ends here


### PR DESCRIPTION
helm-projectile is currently **broken against Projectile master** because the recent Projectile cleanups removed APIs it relied on. This restores compatibility and, since the project had no tests or CI, adds both so this kind of drift gets caught going forward.

### Compatibility (commit 1)
- **Commander gone.** Projectile replaced its single-key commander (`def-projectile-commander-method` / `projectile-commander-bindings`) with the `projectile-dispatch` transient. helm-projectile's `helm-projectile-commander-bindings` used the removed macro, so enabling helm-projectile errored and the file no longer byte-compiled. Dropped it; `C-c p m` now opens `projectile-dispatch`.
- **browse-dirty gone.** `projectile-browse-dirty-projects` and the `vc-dir`-scraping helper it called were removed; dropped `helm-projectile-browse-dirty-projects` and its source/keymap to match.
- Removed a dead `[remap projectile-ack]` (`projectile-ack` never existed).
- Bumped the Emacs floor to 27.1 to match Projectile's own minimum.

### Tests + CI (commit 2)
- A Buttercup suite (Eldev pulls helm/projectile/buttercup from the archives). It covers the regression directly: `helm-projectile-toggle` must enable/disable without error and (un)install its remaps.
- A GitHub Actions workflow across Emacs 27.2-30.2 + snapshot, running inside the `silex/emacs` Docker images (avoids the GitHub-API rate-limiting the Nix-based setup-emacs action hits).

Verified locally: `eldev compile --warnings-as-errors` is clean and all specs pass against the in-tree Projectile master (with the removals) + helm 4.0.

Note: `C-c p m` opening Projectile's (non-Helm) dispatch menu is a minor UX change for Helm users vs. the old Helm-flavored commander. If we want Helm variants surfaced there later, that's a separate enhancement.