### PR TITLE
Add a streaming file picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add `helm-projectile-find-file-streaming`, a Helm file picker that streams candidates as Projectile's indexing command lists them (using a Helm async source) instead of waiting for the whole project to be indexed. Useful on large or remote projects. For Git projects it lists exactly what the indexing command prints, so unlike `helm-projectile-find-file' it doesn't fold in submodule files or drop deleted-but-unstaged ones.
+
 ### Changes
 
 * Restore compatibility with Projectile's `master`, which removed several commands helm-projectile relied on:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ these are the supported commands:
 
 * `helm-projectile-switch-project`
 * `helm-projectile-find-file`
+* `helm-projectile-find-file-streaming` (streams candidates as the project is indexed)
 * `helm-projectile-find-file-in-known-projects`
 * `helm-projectile-find-file-dwim`
 * `helm-projectile-find-dir`

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1086,6 +1086,57 @@ With a prefix ARG invalidates the cache first."
                                (cdr file-res))
                        file-res))))
 
+(defun helm-projectile--files-stream-command ()
+  "Return the shell command that streams the current project's files.
+The command is Projectile's own indexing command for the project's VCS
+\(see `projectile-get-ext-command'), so it honours the project's setup.
+Its NUL-separated output is piped through `tr' to newline-separate it,
+because Helm's process sources split their input on newlines.  Signals a
+`user-error' when external-command indexing is unavailable."
+  (let* ((default-directory (projectile-project-root))
+         (command (projectile-get-ext-command (projectile-project-vcs))))
+    (unless (and (stringp command) (not (string-empty-p command)))
+      (user-error "External-command indexing is unavailable for this project"))
+    ;; Octal \000 (not \0) so the escape is understood by both GNU and BSD tr.
+    (concat command " | tr '\\000' '\\n'")))
+
+(defun helm-projectile--files-process ()
+  "Start the project indexing command as a process for streaming candidates."
+  (let ((default-directory (projectile-project-root)))
+    (start-process-shell-command
+     "helm-projectile-files" nil (helm-projectile--files-stream-command))))
+
+(defvar helm-source-projectile-files-streaming
+  (helm-build-async-source "Projectile files (streaming)"
+    :candidates-process #'helm-projectile--files-process
+    ;; Candidates arrive as project-relative paths; strip a leading "./"
+    ;; (as Projectile does) and pair each with its absolute path so the
+    ;; file actions get a real filename to act on.
+    :filtered-candidate-transformer
+    (lambda (candidates _source)
+      (helm-projectile--files-display-real
+       (mapcar (lambda (c) (string-remove-prefix "./" c)) candidates)
+       (projectile-project-root)))
+    :keymap helm-projectile-find-file-map
+    :help-message 'helm-ff-help-message
+    :mode-line helm-read-file-name-mode-line-string
+    :action helm-projectile-file-actions
+    :persistent-action #'helm-projectile-file-persistent-action
+    :persistent-help "Preview file"
+    :candidate-number-limit 9999)
+  "Helm async source that streams the project's files.
+Candidates are produced by Projectile's own indexing command and appear as
+they are listed, instead of blocking until the whole project is indexed.
+
+Note: for Git projects this lists exactly what the indexing command prints,
+which (unlike `helm-projectile-find-file') does not fold in submodule files
+or drop deleted-but-unstaged files.")
+
+;;;###autoload(autoload 'helm-projectile-find-file-streaming "helm-projectile" nil t)
+(helm-projectile-command "find-file-streaming"
+                         'helm-source-projectile-files-streaming
+                         "Find file (streaming): ")
+
 (defun helm-projectile--find-file-dwim-1 (one-candidate-action actions prompt)
   "Find file at point based on context.
 Execute ONE-CANDIDATE-ACTION when there is a single file returned by

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -66,6 +66,25 @@
       (expect (mapcar #'cdr result)
               :to-equal '("/proj/a.el" "/proj/src/b.el")))))
 
+(describe "helm-projectile streaming file source"
+  (it "defines the streaming command and its source"
+    (expect (commandp 'helm-projectile-find-file-streaming) :to-be-truthy)
+    (expect (boundp 'helm-source-projectile-files-streaming) :to-be-truthy))
+
+  (it "builds a newline-translating shell command from the project's indexer"
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'git)
+    (spy-on 'projectile-get-ext-command
+            :and-return-value "git ls-files -zco --exclude-standard")
+    (expect (helm-projectile--files-stream-command)
+            :to-equal "git ls-files -zco --exclude-standard | tr '\\000' '\\n'"))
+
+  (it "errors when external-command indexing is unavailable"
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'none)
+    (spy-on 'projectile-get-ext-command :and-return-value nil)
+    (expect (helm-projectile--files-stream-command) :to-throw 'user-error)))
+
 (describe "removed features"
   ;; Mirrors Projectile dropping its single-key commander and the
   ;; browse-dirty-projects command; helm-projectile must not resurrect them.


### PR DESCRIPTION
Tier-2 follow-up to #198. Adds `helm-projectile-find-file-streaming`, an opt-in Helm file picker that streams candidates as Projectile's indexing command lists them (via a Helm async `:candidates-process`), instead of blocking until the whole project is indexed. Handy on large or remote projects.

- Built on the stable `projectile-get-ext-command` / `projectile-project-vcs` API, so it works on the declared Projectile floor (no dependency on the unreleased 2.10 producer seam).
- NUL output is piped through `tr` because Helm's process sources split on newlines (same approach as `projectile-consult`).
- **Caveat (documented on the source):** for Git projects it lists exactly what the indexing command prints, so unlike `helm-projectile-find-file` it does not fold in submodule files or drop deleted-but-unstaged ones. It's a separate, opt-in command and doesn't change the existing picker.

Reuses the existing `helm-projectile-command` macro (prefix-arg cache invalidation, project-root requirement, etc.) and the existing `helm-projectile--files-display-real` for display/real pairs. Specs cover the command builder and the unavailable-indexing error path.

(Tier-3 note: I also examined the per-keystroke `hack-dir-local-variables-non-file-buffer` in the file source's `filtered-candidate-transformer`. It's a marginal cost in an untested dwim path, so I left it rather than risk a regression without test coverage.)