### PR TITLE
Fix error signalling and honor helm-projectile-fuzzy-match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix a crash in the "switch project and search" ag/rg actions when the selected path contained a `%`: the path was handed to `error` as a format string.
 * Report a failed `helm-rg` auto-install instead of silently swallowing the error.
+* Honor `helm-projectile-fuzzy-match` in the file, directory and project sources. They stored the option's symbol rather than its value, so fuzzy matching was effectively always on and setting the variable to `nil` had no effect.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changes
 
 * Signal normal situations (not in a project, no other file found, `ack` missing, etc.) with `user-error` instead of `error`, so they no longer drop into the debugger when `debug-on-error` is enabled.
+* Fix the `:type` of `helm-projectile-grep-or-ack-actions`, which was declared as `symbol` but holds a list, so Customize could not edit it.
 
 ## 1.5.0 (2026-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Fix a crash in the "switch project and search" ag/rg actions when the selected path contained a `%`: the path was handed to `error` as a format string.
 * Report a failed `helm-rg` auto-install instead of silently swallowing the error.
 
+### Changes
+
+* Signal normal situations (not in a project, no other file found, `ack` missing, etc.) with `user-error` instead of `error`, so they no longer drop into the debugger when `debug-on-error` is enabled.
+
 ## 1.5.0 (2026-06-30)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Fix a crash in the "switch project and search" ag/rg actions when the selected path contained a `%`: the path was handed to `error` as a format string.
+* Report a failed `helm-rg` auto-install instead of silently swallowing the error.
+
 ## 1.5.0 (2026-06-30)
 
 ### New features

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1557,9 +1557,9 @@ searcher used is determined by the value of `helm-grep-ag-command'."
               (lambda ()
                 (helm-projectile--ag-1 (file-truename directory) input))))
         (projectile-switch-project-by-name (projectile-project-root directory)))
-    (error (if (file-directory-p directory)
-               (format "Directory %s is not in any project!" directory)
-             (format "Not a directory %s" directory)))))
+    (user-error "%s" (if (file-directory-p directory)
+                         (format "Directory %s is not in any project!" directory)
+                       (format "Not a directory %s" directory)))))
 
 ;; Declare/define these to satisfy the byte compiler
 (defvar helm-rg-prepend-file-name-line-at-top-of-matches)
@@ -1602,7 +1602,7 @@ Otherwise ask to install package`helm-rg' and execute BODY."
                 (package-refresh-contents)
                 (package-install 'helm-rg)
                 ,@body)
-            (error "`helm-rg' is not available.  Is MELPA in your `package-archives'?")))
+            (error (user-error "`helm-rg' is not available.  Is MELPA in your `package-archives'?"))))
          (t
           (error "Cannot execute search with ripgrep (rg)"))))
 
@@ -1656,9 +1656,9 @@ package `helm-rg'."
                 (lambda ()
                   (helm-projectile--rg-1 (file-truename directory) input))))
           (projectile-switch-project-by-name (projectile-project-root directory)))
-      (error (if (file-directory-p directory)
-                 (format "Directory %s is not in any project!" directory)
-               (format "Not a directory %s" directory))))))
+      (user-error "%s" (if (file-directory-p directory)
+                           (format "Directory %s is not in any project!" directory)
+                         (format "Not a directory %s" directory))))))
 
 ;;;###autoload
 (defun helm-projectile-toggle (toggle)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -485,7 +485,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
                                                           files)
                                                 (list candidate))))
               (rename-buffer dired-buffer-name))))
-      (error "You're not in a Dired buffer to add"))))
+      (user-error "You're not in a Dired buffer to add"))))
 
 (defun helm-projectile-dired-files-delete-action (candidate)
   "Delete selected entries from a Dired buffer.
@@ -958,7 +958,7 @@ With a prefix ARG invalidates the cache first."
      (if (projectile-project-p)
          (projectile-maybe-invalidate-cache arg)
        (unless ,not-require-root
-         (error "You're not in a project")))
+         (user-error "You're not in a project")))
      (let ((helm-ff-transformer-show-only-basename nil)
            ;; for consistency, we should just let Projectile take care of ignored files
            (helm-boring-file-regexp-list nil))
@@ -1221,7 +1221,7 @@ variable `projectile-other-file-alist'."
                     :buffer "*helm projectile*"
                     :truncate-lines helm-projectile-truncate-lines
                     :prompt (projectile-prepend-project-name prompt)))))
-      (error "No other file found"))))
+      (user-error "No other file found"))))
 
 ;;;###autoload
 (defun helm-projectile-find-other-file (&optional flex-matching)
@@ -1407,7 +1407,7 @@ DIR is the project root, if not set then current project root is used.
 FILES is a list of file patterns to search in.  When called with a
 prefix argument then ask for FILES."
   (interactive)
-  (let* ((project-root (or dir (projectile-project-root) (error "You're not in a project")))
+  (let* ((project-root (or dir (projectile-project-root) (user-error "You're not in a project")))
          (include (if (equal current-prefix-arg '(4))
                       (read-string (projectile-prepend-project-name "Grep in: "))
                     files)))
@@ -1438,7 +1438,7 @@ DIR directory where to search, if not set then current project root is
 used.  TYPES is a list of types to include in search.  When called with
 a prefix argument, then ask for TYPES."
   (interactive)
-  (let* ((project-root (or dir (projectile-project-root) (error "You're not in a project")))
+  (let* ((project-root (or dir (projectile-project-root) (user-error "You're not in a project")))
          (ignored (when (helm-projectile--projectile-ignore-strategy)
                     (mapconcat
                      'identity
@@ -1461,7 +1461,7 @@ a prefix argument, then ask for TYPES."
          (helm-ack-grep-executable (cond
                                     ((executable-find "ack") "ack")
                                     ((executable-find "ack-grep") "ack-grep")
-                                    (t (error "Neither 'ack' nor 'ack-grep' is available"))))
+                                    (t (user-error "Neither 'ack' nor 'ack-grep' is available"))))
          (include (if (equal current-prefix-arg '(4))
                       (let ((helm-grep-default-recurse-command helm-ack-grep-executable)
                             (helm-grep-default-command helm-ack-grep-executable))
@@ -1546,7 +1546,7 @@ searcher used is determined by the value of `helm-grep-ag-command'."
       (helm-projectile--ag-1 (projectile-project-root)
                              (helm-projectile--ag--region-selection)
                              options)
-    (error "You're not in a project")))
+    (user-error "You're not in a project")))
 
 (defun helm-projectile--switch-project-and-ag-action (directory)
   "Switch to a project containing DIRECTORY then run ag in the DIRECTORY."
@@ -1604,7 +1604,7 @@ Otherwise ask to install package`helm-rg' and execute BODY."
                 ,@body)
             (error (user-error "`helm-rg' is not available.  Is MELPA in your `package-archives'?"))))
          (t
-          (error "Cannot execute search with ripgrep (rg)"))))
+          (user-error "Cannot execute search with ripgrep (rg)"))))
 
 (defun helm-projectile--rg-1 (directory input)
   "Call `helm-rg' with DIRECTORY.
@@ -1637,7 +1637,7 @@ package `helm-rg'."
     (if (projectile-project-p)
         (helm-projectile--rg-1 (projectile-project-root)
                                (helm-projectile-rg--region-selection))
-      (error "You're not in a project"))))
+      (user-error "You're not in a project"))))
 
 (defun helm-projectile--switch-project-and-rg-action (directory)
   "Switch to a project containing DIRECTORY then run rg in the DIRECTORY.

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -289,7 +289,10 @@ When `projectile-switch-project-action' is `projectile-find-file' a
   ((candidates :initform (lambda () (with-helm-current-buffer
                                       (mapcar #'copy-sequence
                                               (projectile-known-projects)))))
-   (fuzzy-match :initform 'helm-projectile-fuzzy-match)
+   ;; Read the variable's *value* here.  A bare or quoted symbol initform
+   ;; would store the symbol itself, which Helm reads as a constant non-nil,
+   ;; forcing fuzzy matching on regardless of `helm-projectile-fuzzy-match'.
+   (fuzzy-match :initform (symbol-value 'helm-projectile-fuzzy-match))
    (keymap :initform 'helm-projectile-projects-map)
    (mode-line :initform 'helm-read-file-name-mode-line-string)
    (action :initform 'helm-source-projectile-projects-actions))
@@ -624,7 +627,7 @@ Meant to be added to `helm-cleanup-hook', from which it removes
                                     (list (expand-file-name helm-pattern)
                                           (expand-file-name helm-pattern root))
                                     files)))))))
-   (fuzzy-match :initform 'helm-projectile-fuzzy-match)
+   (fuzzy-match :initform (symbol-value 'helm-projectile-fuzzy-match))
    (keymap :initform 'helm-projectile-find-file-map)
    (help-message :initform 'helm-ff-help-message)
    (mode-line :initform 'helm-read-file-name-mode-line-string)
@@ -782,7 +785,7 @@ Meant to be added to `helm-cleanup-hook', from which it removes
                                                (append '("./") (projectile-current-project-dirs))
                                              (projectile-current-project-dirs))))
                                  (helm-projectile--files-display-real dirs (projectile-project-root)))))))
-   (fuzzy-match :initform 'helm-projectile-fuzzy-match)
+   (fuzzy-match :initform (symbol-value 'helm-projectile-fuzzy-match))
    (action-transformer :initform 'helm-find-files-action-transformer)
    (keymap :initform (let ((map (make-sparse-keymap)))
                        (set-keymap-parent map helm-map)

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -68,8 +68,6 @@
   :group 'helm
   :link `(url-link :tag "GitHub" "https://github.com/bbatsov/helm-projectile"))
 
-(defvar helm-projectile-current-project-root)
-
 (defcustom helm-projectile-truncate-lines nil
   "Truncate lines in helm projectile commands when non--nil.
 
@@ -1307,7 +1305,7 @@ When set to `search-tool', the above does not happen."
     "Find file other window" helm-grep-other-window)
   "Available actions for `helm-projectile-grep-or-ack'.
 The contents of this list are passed as the arguments to `helm-make-actions'."
-  :type 'symbol
+  :type '(repeat sexp)
   :group 'helm-projectile)
 
 (defcustom helm-projectile-set-input-automatically t

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -85,6 +85,15 @@
     (spy-on 'projectile-get-ext-command :and-return-value nil)
     (expect (helm-projectile--files-stream-command) :to-throw 'user-error)))
 
+(describe "helm-projectile--switch-project-and-ag-action"
+  ;; A directory name can legally contain a `%'; the error path used to feed
+  ;; it straight to `error' as a format string, which crashed with "Not enough
+  ;; arguments for format string" instead of reporting the real problem.
+  (it "reports a non-directory argument containing `%' without a format crash"
+    (spy-on 'file-directory-p :and-return-value nil)
+    (expect (helm-projectile--switch-project-and-ag-action "/no/such/dir%s")
+            :to-throw 'user-error)))
+
 (describe "removed features"
   ;; Mirrors Projectile dropping its single-key commander and the
   ;; browse-dirty-projects command; helm-projectile must not resurrect them.

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -94,6 +94,19 @@
     (expect (helm-projectile--switch-project-and-ag-action "/no/such/dir%s")
             :to-throw 'user-error)))
 
+(describe "user-facing error conditions"
+  ;; Normal situations (no project, no other file, ...) should signal
+  ;; `user-error', not `error', so they don't trip the debugger when a user
+  ;; has `debug-on-error' enabled.
+  (it "signals user-error when running ag outside a project"
+    (spy-on 'projectile-project-p :and-return-value nil)
+    (expect (helm-projectile-ag) :to-throw 'user-error))
+
+  (it "signals user-error when there is no other file"
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'projectile-get-other-files :and-return-value nil)
+    (expect (helm-projectile-find-other-file) :to-throw 'user-error)))
+
 (describe "removed features"
   ;; Mirrors Projectile dropping its single-key commander and the
   ;; browse-dirty-projects command; helm-projectile must not resurrect them.

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -94,6 +94,20 @@
     (expect (helm-projectile--switch-project-and-ag-action "/no/such/dir%s")
             :to-throw 'user-error)))
 
+(describe "helm-projectile-fuzzy-match"
+  ;; The EIEIO file/dir/project sources used to store the *symbol*
+  ;; `helm-projectile-fuzzy-match' in their `fuzzy-match' slot, which Helm
+  ;; reads as a constant non-nil, so disabling the option had no effect.
+  (it "propagates a disabled setting to the source's fuzzy-match slot"
+    (let ((helm-projectile-fuzzy-match nil))
+      (expect (slot-value (helm-source-projectile-file :name "t") 'fuzzy-match)
+              :to-be nil)))
+
+  (it "propagates an enabled setting to the source's fuzzy-match slot"
+    (let ((helm-projectile-fuzzy-match t))
+      (expect (slot-value (helm-source-projectile-file :name "t") 'fuzzy-match)
+              :to-be t))))
+
 (describe "user-facing error conditions"
   ;; Normal situations (no project, no other file, ...) should signal
   ;; `user-error', not `error', so they don't trip the debugger when a user


### PR DESCRIPTION
A batch of small correctness fixes shaken out of a code review.

- The ag/rg "switch project and search" actions passed the selected path to `error` as a format string, so a path containing a `%` crashed with "Not enough arguments for format string." A failed `helm-rg` auto-install was also swallowed by a `condition-case` handler that only evaluated its message string. Both now signal properly.
- Normal situations (no project, no other file, missing `ack`, ...) now use `user-error` instead of `error`, so they don't drop into the debugger under `debug-on-error`.
- The file/dir/project sources stored the *symbol* `helm-projectile-fuzzy-match` in their `fuzzy-match` slot instead of its value, so fuzzy matching was effectively always on and disabling the option did nothing.
- Small cleanups: correct the `:type` of `helm-projectile-grep-or-ack-actions` (a list, not a symbol) and drop the unused `helm-projectile-current-project-root`.

Each fix has a regression test; the suite grows from 8 to 14 specs and the file compiles clean.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing behavior added)