### PR TITLE
Avoid per-keystroke dir-locals walk in the file source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+* Speed up typing in `helm-projectile-find-file`: the file source's per-keystroke transformer no longer opens a temp buffer and walks the tree for `.dir-locals.el` on every input change (it never used those dir-locals anyway).
 * Signal normal situations (not in a project, no other file found, `ack` missing, etc.) with `user-error` instead of `error`, so they no longer drop into the debugger when `debug-on-error` is enabled.
 * Fix the `:type` of `helm-projectile-grep-or-ack-actions`, which was declared as `symbol` but holds a list, so Customize could not edit it.
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -608,23 +608,25 @@ Meant to be added to `helm-cleanup-hook', from which it removes
                     (helm-projectile--files-display-real (projectile-current-project-files)
                                                          (projectile-project-root))))))
    (filtered-candidate-transformer
+    ;; Runs on every input change, so keep it cheap: unlike the candidates
+    ;; function it doesn't list project files, so it needs neither a temp
+    ;; buffer nor a `hack-dir-local-variables-non-file-buffer' filesystem walk
+    ;; (which would search for `.dir-locals.el' up the tree on each keystroke).
     :initform (lambda (files _source)
-                (with-temp-buffer
-                  (hack-dir-local-variables-non-file-buffer)
-                  (let* ((root (projectile-project-root))
-                         (file-at-root (file-relative-name (expand-file-name helm-pattern root))))
-                    (if (or (string-empty-p helm-pattern)
-                            (assoc helm-pattern files))
-                        files
-                      (if (equal helm-pattern file-at-root)
-                          (cl-acons (helm-ff-prefix-filename helm-pattern nil t)
-                                    (expand-file-name helm-pattern)
-                                    files)
-                        (cl-pairlis (list (helm-ff-prefix-filename helm-pattern nil t)
-                                          (helm-ff-prefix-filename file-at-root nil t))
-                                    (list (expand-file-name helm-pattern)
-                                          (expand-file-name helm-pattern root))
-                                    files)))))))
+                (let* ((root (projectile-project-root))
+                       (file-at-root (file-relative-name (expand-file-name helm-pattern root))))
+                  (if (or (string-empty-p helm-pattern)
+                          (assoc helm-pattern files))
+                      files
+                    (if (equal helm-pattern file-at-root)
+                        (cl-acons (helm-ff-prefix-filename helm-pattern nil t)
+                                  (expand-file-name helm-pattern)
+                                  files)
+                      (cl-pairlis (list (helm-ff-prefix-filename helm-pattern nil t)
+                                        (helm-ff-prefix-filename file-at-root nil t))
+                                  (list (expand-file-name helm-pattern)
+                                        (expand-file-name helm-pattern root))
+                                  files))))))
    (fuzzy-match :initform (symbol-value 'helm-projectile-fuzzy-match))
    (keymap :initform 'helm-projectile-find-file-map)
    (help-message :initform 'helm-ff-help-message)

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -94,6 +94,20 @@
     (expect (helm-projectile--switch-project-and-ag-action "/no/such/dir%s")
             :to-throw 'user-error)))
 
+(describe "helm-projectile file source transformer"
+  ;; The transformer runs on every keystroke, so it must not do the
+  ;; `.dir-locals.el' filesystem walk that the candidates function needs.
+  (it "does not hack dir-local variables on every update"
+    (spy-on 'hack-dir-local-variables-non-file-buffer)
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (let* ((src (helm-source-projectile-file :name "t"))
+           (transformer (slot-value src 'filtered-candidate-transformer))
+           (helm-pattern ""))
+      (expect (funcall transformer '(("a.el" . "/proj/a.el")) src)
+              :to-equal '(("a.el" . "/proj/a.el")))
+      (expect 'hack-dir-local-variables-non-file-buffer
+              :not :to-have-been-called))))
+
 (describe "helm-projectile-fuzzy-match"
   ;; The EIEIO file/dir/project sources used to store the *symbol*
   ;; `helm-projectile-fuzzy-match' in their `fuzzy-match' slot, which Helm


### PR DESCRIPTION
`helm-projectile-find-file`'s file source ran a `hack-dir-local-variables-non-file-buffer` (which walks the tree looking for `.dir-locals.el`) inside a temp buffer on *every* keystroke, even though the transformer never lists project files and so never used those dir-locals. Dropping the wrapper makes typing in large projects noticeably snappier; `projectile-project-root` returns the same value without it.

A regression test asserts the transformer no longer touches dir-locals.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing behavior change)