### PR TITLE
Drive helm-projectile-toggle from a remap table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Signal normal situations (not in a project, no other file found, `ack` missing, etc.) with `user-error` instead of `error`, so they no longer drop into the debugger when `debug-on-error` is enabled.
 * Fix the `:type` of `helm-projectile-grep-or-ack-actions`, which was declared as `symbol` but holds a list, so Customize could not edit it.
 
+### Internal
+
+* Drive `helm-projectile-toggle`'s command remaps from a single table (`helm-projectile--command-remaps`) instead of two hand-maintained copies of ~20 `define-key` calls.
+
 ## 1.5.0 (2026-06-30)
 
 ### New features

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1664,78 +1664,68 @@ package `helm-rg'."
                          (format "Not a directory %s" directory))))))
 
 ;;;###autoload
+(defconst helm-projectile--command-remaps
+  '((projectile-find-other-file . helm-projectile-find-other-file)
+    (projectile-find-other-file-other-window . helm-projectile-find-other-file-other-window)
+    (projectile-find-other-file-other-frame . helm-projectile-find-other-file-other-frame)
+    (projectile-find-file . helm-projectile-find-file)
+    (projectile-find-file-other-window . helm-projectile-find-file-other-window)
+    (projectile-find-file-other-frame . helm-projectile-find-file-other-frame)
+    (projectile-find-file-in-known-projects . helm-projectile-find-file-in-known-projects)
+    (projectile-find-file-dwim . helm-projectile-find-file-dwim)
+    (projectile-find-file-dwim-other-window . helm-projectile-find-file-dwim-other-window)
+    (projectile-find-file-dwim-other-frame . helm-projectile-find-file-dwim-other-frame)
+    (projectile-find-dir . helm-projectile-find-dir)
+    (projectile-find-dir-other-window . helm-projectile-find-dir-other-window)
+    (projectile-find-dir-other-frame . helm-projectile-find-dir-other-frame)
+    (projectile-switch-project . helm-projectile-switch-project)
+    (projectile-recentf . helm-projectile-recentf)
+    (projectile-switch-to-buffer . helm-projectile-switch-to-buffer)
+    (projectile-switch-to-buffer-other-window . helm-projectile-switch-to-buffer-other-window)
+    (projectile-switch-to-buffer-other-frame . helm-projectile-switch-to-buffer-other-frame)
+    (projectile-grep . helm-projectile-grep)
+    (projectile-ag . helm-projectile-ag)
+    (projectile-ripgrep . helm-projectile-rg))
+  "Alist mapping Projectile commands to their `helm-projectile' replacements.
+`helm-projectile-toggle' installs and removes these as command remaps on
+`projectile-mode-map'.  The `switch-project' other-window/other-frame
+commands are handled separately because they need a compatibility
+fallback.")
+
 (defun helm-projectile-toggle (toggle)
   "Toggle Helm version of Projectile commands.
 When TOGGLE is greater than 0 turn Helm version of Projectile commands
 on.  When TOGGLE is is less or equal to 0 turn Helm version of commands
 off."
-  (if (> toggle 0)
-      (progn
+  (let ((enable (> toggle 0)))
+    (if enable
         (when (eq projectile-switch-project-action #'projectile-find-file)
           (setq projectile-switch-project-action #'helm-projectile-find-file))
-        (define-key projectile-mode-map [remap projectile-find-other-file] #'helm-projectile-find-other-file)
-        (define-key projectile-mode-map [remap projectile-find-other-file-other-window] #'helm-projectile-find-other-file-other-window)
-        (define-key projectile-mode-map [remap projectile-find-other-file-other-frame] #'helm-projectile-find-other-file-other-frame)
-        (define-key projectile-mode-map [remap projectile-find-file] #'helm-projectile-find-file)
-        (define-key projectile-mode-map [remap projectile-find-file-other-window] #'helm-projectile-find-file-other-window)
-        (define-key projectile-mode-map [remap projectile-find-file-other-frame] #'helm-projectile-find-file-other-frame)
-        (define-key projectile-mode-map [remap projectile-find-file-in-known-projects] #'helm-projectile-find-file-in-known-projects)
-        (define-key projectile-mode-map [remap projectile-find-file-dwim] #'helm-projectile-find-file-dwim)
-        (define-key projectile-mode-map [remap projectile-find-file-dwim-other-window] #'helm-projectile-find-file-dwim-other-window)
-        (define-key projectile-mode-map [remap projectile-find-file-dwim-other-frame] #'helm-projectile-find-file-dwim-other-frame)
-        (define-key projectile-mode-map [remap projectile-find-dir] #'helm-projectile-find-dir)
-        (define-key projectile-mode-map [remap projectile-find-dir-other-window] #'helm-projectile-find-dir-other-window)
-        (define-key projectile-mode-map [remap projectile-find-dir-other-frame] #'helm-projectile-find-dir-other-frame)
-        (define-key projectile-mode-map [remap projectile-switch-project] #'helm-projectile-switch-project)
-        ;; At the time of writing projectile didn't have neither
-        ;; `projectile-switch-to-project-other-window' nor
-        ;; `projectile-switch-to-project-other-frame' (hopefully these will be
-        ;; names should they be added).  Adding `helm-projectile' bindings in a
-        ;; - hopefully - backward compatible way, by setting up keys in
-        ;; `projectile-command-map'.
-        (if (where-is-internal 'projectile-switch-project-other-window projectile-mode-map nil t t)
-            (define-key projectile-mode-map [remap projectile-switch-project-other-window] #'helm-projectile-switch-project-other-window)
-          (define-key projectile-command-map (kbd "4 p") #'helm-projectile-switch-project-other-window))
-        (if (where-is-internal 'projectile-switch-project-other-frame projectile-mode-map nil t t)
-            (define-key projectile-mode-map [remap projectile-switch-project-other-frame] #'helm-projectile-switch-project-other-frame)
-          (define-key projectile-command-map (kbd "5 p") #'helm-projectile-switch-project-other-frame))
-        (define-key projectile-mode-map [remap projectile-recentf] #'helm-projectile-recentf)
-        (define-key projectile-mode-map [remap projectile-switch-to-buffer] #'helm-projectile-switch-to-buffer)
-        (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-window] #'helm-projectile-switch-to-buffer-other-window)
-        (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-frame] #'helm-projectile-switch-to-buffer-other-frame)
-        (define-key projectile-mode-map [remap projectile-grep] #'helm-projectile-grep)
-        (define-key projectile-mode-map [remap projectile-ag] #'helm-projectile-ag)
-        (define-key projectile-mode-map [remap projectile-ripgrep] #'helm-projectile-rg))
-    (progn
       (when (eq projectile-switch-project-action #'helm-projectile-find-file)
-        (setq projectile-switch-project-action #'projectile-find-file))
-      (define-key projectile-mode-map [remap projectile-find-other-file] nil)
-      (define-key projectile-mode-map [remap projectile-find-other-file-other-window] nil)
-      (define-key projectile-mode-map [remap projectile-find-other-file-other-frame] nil)
-      (define-key projectile-mode-map [remap projectile-find-file] nil)
-      (define-key projectile-mode-map [remap projectile-find-file-other-window] nil)
-      (define-key projectile-mode-map [remap projectile-find-file-other-frame] nil)
-      (define-key projectile-mode-map [remap projectile-find-file-in-known-projects] nil)
-      (define-key projectile-mode-map [remap projectile-find-file-dwim] nil)
-      (define-key projectile-mode-map [remap projectile-find-file-dwim-other-window] nil)
-      (define-key projectile-mode-map [remap projectile-find-file-dwim-other-frame] nil)
-      (define-key projectile-mode-map [remap projectile-find-dir] nil)
-      (define-key projectile-mode-map [remap projectile-find-dir-other-window] nil)
-      (define-key projectile-mode-map [remap projectile-find-dir-other-frame] nil)
-      (define-key projectile-mode-map [remap projectile-switch-project] nil)
+        (setq projectile-switch-project-action #'projectile-find-file)))
+    (pcase-dolist (`(,command . ,helm-command) helm-projectile--command-remaps)
+      (define-key projectile-mode-map (vector 'remap command)
+                  (and enable helm-command)))
+    (if enable
+        (progn
+          ;; At the time of writing projectile didn't have neither
+          ;; `projectile-switch-to-project-other-window' nor
+          ;; `projectile-switch-to-project-other-frame' (hopefully these will be
+          ;; names should they be added).  Adding `helm-projectile' bindings in a
+          ;; - hopefully - backward compatible way, by setting up keys in
+          ;; `projectile-command-map'.
+          (if (where-is-internal 'projectile-switch-project-other-window projectile-mode-map nil t t)
+              (define-key projectile-mode-map [remap projectile-switch-project-other-window] #'helm-projectile-switch-project-other-window)
+            (define-key projectile-command-map (kbd "4 p") #'helm-projectile-switch-project-other-window))
+          (if (where-is-internal 'projectile-switch-project-other-frame projectile-mode-map nil t t)
+              (define-key projectile-mode-map [remap projectile-switch-project-other-frame] #'helm-projectile-switch-project-other-frame)
+            (define-key projectile-command-map (kbd "5 p") #'helm-projectile-switch-project-other-frame)))
       (if (where-is-internal 'helm-projectile-switch-project-other-window projectile-command-map nil t t)
           (define-key projectile-mode-map (kbd "4 p") nil)
         (define-key projectile-mode-map [remap projectile-switch-project-other-window] nil))
       (if (where-is-internal 'helm-projectile-switch-project-other-frame projectile-command-map nil t t)
           (define-key projectile-mode-map (kbd "5 p") nil)
-        (define-key projectile-mode-map [remap projectile-switch-project-other-frame] nil))
-      (define-key projectile-mode-map [remap projectile-recentf] nil)
-      (define-key projectile-mode-map [remap projectile-switch-to-buffer] nil)
-      (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-window] nil)
-      (define-key projectile-mode-map [remap projectile-switch-to-buffer-other-frame] nil)
-      (define-key projectile-mode-map [remap projectile-grep] nil)
-      (define-key projectile-mode-map [remap projectile-ag] nil)
-      (define-key projectile-mode-map [remap projectile-ripgrep] nil))))
+        (define-key projectile-mode-map [remap projectile-switch-project-other-frame] nil)))))
 
 ;;;###autoload
 (defun helm-projectile (&optional arg)

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -49,13 +49,24 @@
     (expect (lookup-key projectile-mode-map [remap projectile-switch-to-buffer])
             :to-be 'helm-projectile-switch-to-buffer)
     (expect (lookup-key projectile-mode-map [remap projectile-grep])
-            :to-be 'helm-projectile-grep))
+            :to-be 'helm-projectile-grep)
+    ;; `ripgrep' is the one remap whose Helm command doesn't share the
+    ;; `helm-projectile-<name>' shape, so guard it explicitly.
+    (expect (lookup-key projectile-mode-map [remap projectile-ripgrep])
+            :to-be 'helm-projectile-rg))
+
+  (it "installs a remap for every command in the table"
+    (helm-projectile-toggle 1)
+    (dolist (entry helm-projectile--command-remaps)
+      (expect (lookup-key projectile-mode-map (vector 'remap (car entry)))
+              :to-be (cdr entry))))
 
   (it "disables without error and clears the remaps"
     (helm-projectile-toggle 1)
     (expect (helm-projectile-toggle 0) :not :to-throw)
-    (expect (lookup-key projectile-mode-map [remap projectile-find-file])
-            :to-be nil)))
+    (dolist (entry helm-projectile--command-remaps)
+      (expect (lookup-key projectile-mode-map (vector 'remap (car entry)))
+              :to-be nil))))
 
 (describe "helm-projectile--files-display-real"
   (it "maps each file to its absolute path under the project root"


### PR DESCRIPTION
`helm-projectile-toggle` kept two hand-maintained copies of ~20 `define-key ... [remap ...]` calls, one to install the Helm remaps and one to clear them, so adding a command meant editing both in lockstep. This collects the straightforward remaps into a single `helm-projectile--command-remaps` alist and loops over it in both directions. The `switch-project` other-window/other-frame bindings keep their `where-is-internal` compatibility fallback and stay out of the table.

Pure refactor, no behavior change. The toggle tests now assert every entry in the table is installed on enable and cleared on disable.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing change)