### PR TITLE
Extract the remote virtual-Dired guard into a macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Internal
 
 * Drive `helm-projectile-toggle`'s command remaps from a single table (`helm-projectile--command-remaps`) instead of two hand-maintained copies of ~20 `define-key` calls.
+* Extract the remote virtual-Dired guard duplicated across the three Dired file actions into a `helm-projectile--with-virtual-dired` macro.
 
 ## 1.5.0 (2026-06-30)
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -416,13 +416,23 @@ project's files over TRAMP can be slow."
   :type 'boolean
   :group 'helm-projectile)
 
+(defmacro helm-projectile--with-virtual-dired (&rest body)
+  "Evaluate BODY unless the virtual Dired manager is disabled here.
+When the project root is remote and
+`helm-projectile-virtual-dired-remote-enable' is nil, show a message
+pointing at that option instead of evaluating BODY."
+  (declare (indent 0) (debug t))
+  `(if (and (file-remote-p (projectile-project-root))
+            (not helm-projectile-virtual-dired-remote-enable))
+       (message "Virtual Dired manager is disabled in remote host. Enable with %s."
+                (propertize "helm-projectile-virtual-dired-remote-enable"
+                            'face 'font-lock-keyword-face))
+     ,@body))
+
 (defun helm-projectile-dired-files-new-action (candidate)
   "Create a Dired buffer from chosen files.
 CANDIDATE is the selected file, but choose the marked files if available."
-  (if (and (file-remote-p (projectile-project-root))
-           (not helm-projectile-virtual-dired-remote-enable))
-      (message "Virtual Dired manager is disabled in remote host. Enable with %s."
-               (propertize "helm-projectile-virtual-dired-remote-enable" 'face 'font-lock-keyword-face))
+  (helm-projectile--with-virtual-dired
     (let ((files (cl-remove-if-not
                   (lambda (f)
                     (not (string= f "")))
@@ -449,10 +459,7 @@ CANDIDATE is the selected file, but choose the marked files if available."
 (defun helm-projectile-dired-files-add-action (candidate)
   "Add files to a Dired buffer.
 CANDIDATE is the selected file.  Used when no file is explicitly marked."
-  (if (and (file-remote-p (projectile-project-root))
-           (not helm-projectile-virtual-dired-remote-enable))
-      (message "Virtual Dired manager is disabled in remote host. Enable with %s."
-               (propertize "helm-projectile-virtual-dired-remote-enable" 'face 'font-lock-keyword-face))
+  (helm-projectile--with-virtual-dired
     (if (eq (with-helm-current-buffer major-mode) 'dired-mode)
         (let* ((marked-files (helm-marked-candidates :with-wildcard t))
                (helm--reading-passwd-or-string t)
@@ -490,10 +497,7 @@ CANDIDATE is the selected file.  Used when no file is explicitly marked."
 (defun helm-projectile-dired-files-delete-action (candidate)
   "Delete selected entries from a Dired buffer.
 CANDIDATE is the selected file.  Used when no file is explicitly marked."
-  (if (and (file-remote-p (projectile-project-root))
-           (not helm-projectile-virtual-dired-remote-enable))
-      (message "Virtual Dired manager is disabled in remote host. Enable with %s."
-               (propertize "helm-projectile-virtual-dired-remote-enable" 'face 'font-lock-keyword-face))
+  (helm-projectile--with-virtual-dired
     (let* ((helm--reading-passwd-or-string t)
            (root (projectile-project-root))
            (dired-buffer-name (with-helm-current-buffer (buffer-name)))

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -105,6 +105,27 @@
     (expect (helm-projectile--switch-project-and-ag-action "/no/such/dir%s")
             :to-throw 'user-error)))
 
+(describe "helm-projectile--with-virtual-dired"
+  (it "runs the body on a local project root"
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (let ((ran nil))
+      (helm-projectile--with-virtual-dired (setq ran t))
+      (expect ran :to-be t)))
+
+  (it "skips the body on a remote root when disabled"
+    (spy-on 'projectile-project-root :and-return-value "/ssh:host:/proj/")
+    (let ((helm-projectile-virtual-dired-remote-enable nil)
+          (ran nil))
+      (helm-projectile--with-virtual-dired (setq ran t))
+      (expect ran :to-be nil)))
+
+  (it "runs the body on a remote root when explicitly enabled"
+    (spy-on 'projectile-project-root :and-return-value "/ssh:host:/proj/")
+    (let ((helm-projectile-virtual-dired-remote-enable t)
+          (ran nil))
+      (helm-projectile--with-virtual-dired (setq ran t))
+      (expect ran :to-be t))))
+
 (describe "helm-projectile-command generated docstrings"
   ;; Every command used to inherit the same "finding files in project"
   ;; docstring; each should now describe what it actually does.


### PR DESCRIPTION
The three virtual-Dired actions (`helm-projectile-dired-files-new-action`, `-add-action`, `-delete-action`) each opened with the same six-line guard that bails out with a message when the project root is remote and `helm-projectile-virtual-dired-remote-enable` is nil. Pull it into a `helm-projectile--with-virtual-dired` macro so the check lives in one place.

Pure refactor. A small test covers the macro's three cases (local, remote-disabled, remote-enabled).

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing change)