### PR TITLE
Add helm-projectile-find-file-strategy for streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add `helm-projectile-find-file-strategy`. Set it to `streaming` to make `helm-projectile-find-file` (and its other-window/other-frame variants) stream candidates as the project is indexed instead of blocking on the full index, without having to switch to the separate `helm-projectile-find-file-streaming` command. Defaults to `sync` (the original behavior).
+
 ### Bugs fixed
 
 * Fix a crash in the "switch project and search" ag/rg actions when the selected path contained a `%`: the path was handed to `error` as a format string.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ Magit or Eshell. `helm-projectile-find-file` reuses actions in
 files. Another reason is that in a large source tree, helm-projectile
 could be slow because it has to open all available sources.
 
+On a large or remote project the up-front indexing that
+`helm-projectile-find-file` does can make the picker slow to appear. If
+that bothers you, set `helm-projectile-find-file-strategy` to
+`streaming` and it (along with its other-window and other-frame
+variants) will stream candidates as Projectile's indexing command lists
+them, instead of waiting for the whole project to be indexed:
+
+```el
+(setq helm-projectile-find-file-strategy 'streaming)
+```
+
+The default is `sync`, the original behavior. Note that for Git projects
+the streaming strategy lists exactly what the indexing command prints,
+so it doesn't fold in submodule files or drop deleted-but-unstaged ones.
+The `helm-projectile-find-file-streaming` command streams regardless of
+this setting.
+
 If you want to use these commands, you have to activate it to replace
 the normal Projectile commands:
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1015,21 +1015,61 @@ Defaults is `helm-projectile-truncate-lines'."
                              'helm-projectile-projects-other-frame-source)
                          "Switch to project: " t)
 
+(defcustom helm-projectile-find-file-strategy 'sync
+  "How `helm-projectile-find-file' lists a project's files.
+
+`sync' (the default) builds the whole file index up front, then hands it
+to Helm.  It is battle-tested and pulls in the extra sources, like the
+files of the current Dired buffer, plus the \"type a brand new file
+name\" behavior.
+
+`streaming' streams candidates as Projectile's own indexing command
+prints them, so the picker appears instantly on large or remote projects
+instead of blocking until indexing finishes.  It lists exactly what the
+indexing command prints, so - like `helm-projectile-find-file-streaming'
+\(which see) - on Git projects it doesn't fold in submodule files or drop
+deleted-but-unstaged ones.
+
+This governs `helm-projectile-find-file' and its other-window and
+other-frame variants.  The dwim commands and
+`helm-projectile-find-file-in-known-projects' always build the full file
+list, because they need it (to match the file at point, or to span every
+known project)."
+  :type '(choice (const :tag "Build the full index first" sync)
+                 (const :tag "Stream candidates as they are indexed" streaming))
+  :group 'helm-projectile)
+
+(defmacro helm-projectile--file-sources (streaming &rest sync)
+  "Choose file sources per `helm-projectile-find-file-strategy'.
+Return the STREAMING source when the strategy is `streaming', otherwise
+the list of SYNC sources.  Expanded inside a `helm-projectile-command'
+body, so the choice is made on each call and toggling the option takes
+effect immediately."
+  `(if (eq helm-projectile-find-file-strategy 'streaming)
+       ,streaming
+     (list ,@sync)))
+
 ;;;###autoload(autoload 'helm-projectile-find-file "helm-projectile" nil t)
 (helm-projectile-command "find-file"
-                         '(helm-source-projectile-dired-files-list
-                           helm-source-projectile-files-list)
+                         (helm-projectile--file-sources
+                          'helm-source-projectile-files-streaming
+                          'helm-source-projectile-dired-files-list
+                          'helm-source-projectile-files-list)
                          "Find file: ")
 ;;;###autoload(autoload 'helm-projectile-find-file-other-window "helm-projectile" nil t)
 (helm-projectile-command "find-file-other-window"
-                         '(helm-source-projectile-dired-files-other-window-list
-                           helm-source-projectile-files-other-window-list)
+                         (helm-projectile--file-sources
+                          'helm-source-projectile-files-streaming-other-window
+                          'helm-source-projectile-dired-files-other-window-list
+                          'helm-source-projectile-files-other-window-list)
                          "Find file (other window): ")
 
 ;;;###autoload(autoload 'helm-projectile-find-file-other-frame "helm-projectile" nil t)
 (helm-projectile-command "find-file-other-frame"
-                         '(helm-source-projectile-dired-files-other-frame-list
-                           helm-source-projectile-files-other-frame-list)
+                         (helm-projectile--file-sources
+                          'helm-source-projectile-files-streaming-other-frame
+                          'helm-source-projectile-dired-files-other-frame-list
+                          'helm-source-projectile-files-other-frame-list)
                          "Find file (other frame): ")
 
 ;;;###autoload(autoload 'helm-projectile-find-file-in-known-projects "helm-projectile" nil t)
@@ -1113,7 +1153,10 @@ because Helm's process sources split their input on newlines.  Signals a
     (start-process-shell-command
      "helm-projectile-files" nil (helm-projectile--files-stream-command))))
 
-(defvar helm-source-projectile-files-streaming
+(defun helm-projectile--make-streaming-source (action)
+  "Build a Helm async source that streams the project's files.
+ACTION is the Helm action list attached to the source (which see
+`helm-projectile-file-actions')."
   (helm-build-async-source "Projectile files (streaming)"
     :candidates-process #'helm-projectile--files-process
     ;; Candidates arrive as project-relative paths; strip a leading "./"
@@ -1127,10 +1170,13 @@ because Helm's process sources split their input on newlines.  Signals a
     :keymap helm-projectile-find-file-map
     :help-message 'helm-ff-help-message
     :mode-line helm-read-file-name-mode-line-string
-    :action helm-projectile-file-actions
+    :action action
     :persistent-action #'helm-projectile-file-persistent-action
     :persistent-help "Preview file"
-    :candidate-number-limit 9999)
+    :candidate-number-limit 9999))
+
+(defvar helm-source-projectile-files-streaming
+  (helm-projectile--make-streaming-source helm-projectile-file-actions)
   "Helm async source that streams the project's files.
 Candidates are produced by Projectile's own indexing command and appear as
 they are listed, instead of blocking until the whole project is indexed.
@@ -1138,6 +1184,20 @@ they are listed, instead of blocking until the whole project is indexed.
 Note: for Git projects this lists exactly what the indexing command prints,
 which (unlike `helm-projectile-find-file') does not fold in submodule files
 or drop deleted-but-unstaged files.")
+
+(defvar helm-source-projectile-files-streaming-other-window
+  (helm-projectile--make-streaming-source
+   (helm-projectile-hack-actions
+    helm-projectile-file-actions
+    '(helm-find-files-other-window . :make-first)))
+  "Like `helm-source-projectile-files-streaming', but opening in another window.")
+
+(defvar helm-source-projectile-files-streaming-other-frame
+  (helm-projectile--make-streaming-source
+   (helm-projectile-hack-actions
+    helm-projectile-file-actions
+    '(find-file-other-frame . :make-first)))
+  "Like `helm-source-projectile-files-streaming', but opening in another frame.")
 
 ;;;###autoload(autoload 'helm-projectile-find-file-streaming "helm-projectile" nil t)
 (helm-projectile-command "find-file-streaming"

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -94,7 +94,53 @@
     (spy-on 'projectile-project-root :and-return-value "/proj/")
     (spy-on 'projectile-project-vcs :and-return-value 'none)
     (spy-on 'projectile-get-ext-command :and-return-value nil)
-    (expect (helm-projectile--files-stream-command) :to-throw 'user-error)))
+    (expect (helm-projectile--files-stream-command) :to-throw 'user-error))
+
+  (it "defines an other-window and other-frame streaming source"
+    (expect (boundp 'helm-source-projectile-files-streaming-other-window) :to-be-truthy)
+    (expect (boundp 'helm-source-projectile-files-streaming-other-frame) :to-be-truthy))
+
+  (it "promotes the matching default action in each streaming variant"
+    (cl-flet ((first-action (src) (cdar (helm-get-attr 'action src))))
+      (expect (first-action helm-source-projectile-files-streaming-other-window)
+              :to-be 'helm-find-files-other-window)
+      (expect (first-action helm-source-projectile-files-streaming-other-frame)
+              :to-be 'find-file-other-frame))))
+
+(describe "helm-projectile-find-file-strategy"
+  (before-each
+    (spy-on 'helm)
+    (spy-on 'projectile-project-p :and-return-value t)
+    (spy-on 'projectile-maybe-invalidate-cache)
+    (spy-on 'projectile-project-name :and-return-value "demo")
+    (spy-on 'projectile-prepend-project-name :and-call-fake #'identity))
+
+  (defun helm-projectile-test--sources ()
+    "Return the `:sources' passed to the most recent stubbed `helm' call."
+    (plist-get (spy-calls-args-for 'helm 0) :sources))
+
+  (it "defaults to sync"
+    (expect helm-projectile-find-file-strategy :to-be 'sync))
+
+  (it "picks the sync sources for each variant by default"
+    (helm-projectile-find-file)
+    (expect (helm-projectile-test--sources)
+            :to-equal '(helm-source-projectile-dired-files-list
+                        helm-source-projectile-files-list)))
+
+  (it "picks the streaming source for each variant when set to streaming"
+    (let ((helm-projectile-find-file-strategy 'streaming))
+      (helm-projectile-find-file)
+      (expect (helm-projectile-test--sources)
+              :to-be 'helm-source-projectile-files-streaming)
+      (spy-calls-reset 'helm)
+      (helm-projectile-find-file-other-window)
+      (expect (helm-projectile-test--sources)
+              :to-be 'helm-source-projectile-files-streaming-other-window)
+      (spy-calls-reset 'helm)
+      (helm-projectile-find-file-other-frame)
+      (expect (helm-projectile-test--sources)
+              :to-be 'helm-source-projectile-files-streaming-other-frame))))
 
 (describe "helm-projectile--switch-project-and-ag-action"
   ;; A directory name can legally contain a `%'; the error path used to feed


### PR DESCRIPTION
`helm-projectile-find-file` builds the whole project file index up front, which is slow to appear on large or remote projects. Streaming already exists as the separate `helm-projectile-find-file-streaming` command, but you had to relearn the command name to get it.

This adds a `helm-projectile-find-file-strategy` option. Set it to `streaming` and `helm-projectile-find-file` (plus its other-window and other-frame variants) streams candidates as Projectile's indexing command lists them. It's read on each call, so toggling takes effect immediately. Defaults to `sync`, the original behavior, so nothing changes out of the box.

The `find-file-dwim` commands and `find-file-in-known-projects` stay sync on purpose: they need the full file list by nature (to match the file at point, or to span every known project). The streaming source is factored into a small builder so the window/frame variants reuse it with the right default action.

Tests cover the dispatch for all three variants under both strategies, plus the new variant sources and their default actions.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [x] You've updated the readme