### PR TITLE
Add a test helper module and broaden unit coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Require Emacs 28.1 and Projectile 3.1.0. Projectile 3.1.0 raised its own minimum to Emacs 28.1 (and pulls in `compat`), so helm-projectile can no longer be installed on Emacs 27. The CI matrix drops the 27.2 job accordingly.
 
+### Internal
+
+* Add a shared test helper module (`test/helm-projectile-test-helper.el`) with a temporary-project sandbox, and broaden unit coverage of the pure helpers (`helm-projectile-hack-actions`, `helm-projectile--wildcard-to-ack-match`, `helm-projectile--move-selection-p`, `helm-projectile--files-display-real`) and `helm-projectile-files-in-current-dired-buffer`.
+
 ## 1.6.0 (2026-07-01)
 
 ### New features

--- a/test/helm-projectile-test-helper.el
+++ b/test/helm-projectile-test-helper.el
@@ -1,0 +1,67 @@
+;;; helm-projectile-test-helper.el --- Shared test helpers -*- lexical-binding: t -*-
+
+;; Copyright © 2011-2026 Bozhidar Batsov
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see `http://www.gnu.org/licenses/'.
+
+;;; Commentary:
+
+;; Fixtures and helpers shared by the helm-projectile test suites: a
+;; temporary-project sandbox (mirroring Projectile's own test helpers) and a
+;; small shim for reading back the arguments of a stubbed `helm' call.
+
+;;; Code:
+
+(require 'helm-projectile)
+(require 'buttercup)
+(require 'cl-lib)
+(require 'dired)
+
+(defmacro helm-projectile-test-with-sandbox (&rest body)
+  "Run BODY with `default-directory' bound to a fresh temporary directory.
+The directory is created before BODY and deleted afterwards, so a suite
+can build a throwaway project tree on disk without touching the user's
+files."
+  (declare (indent 0) (debug t))
+  `(let ((default-directory (file-name-as-directory
+                             (make-temp-file "helm-projectile-test" t))))
+     (unwind-protect
+         (progn ,@body)
+       (delete-directory default-directory t))))
+
+(defmacro helm-projectile-test-with-files (files &rest body)
+  "Create FILES under `default-directory', then run BODY.
+FILES is a list of relative paths.  A path ending in \"/\" is created as a
+directory; any other path has its parent directories created and is then
+touched as an empty file.  Meant to be nested inside
+`helm-projectile-test-with-sandbox'."
+  (declare (indent 1) (debug t))
+  `(progn
+     (dolist (f ,files)
+       (if (string-suffix-p "/" f)
+           (make-directory f t)
+         (when-let* ((dir (file-name-directory f)))
+           (make-directory dir t))
+         (write-region "" nil f nil 'silent)))
+     ,@body))
+
+(defun helm-projectile-test--sources (&optional n)
+  "Return the `:sources' of the N-th (default 0) stubbed `helm' call.
+A `(spy-on \\='helm)' must be active for this to have anything to read."
+  (plist-get (spy-calls-args-for 'helm (or n 0)) :sources))
+
+(provide 'helm-projectile-test-helper)
+;;; helm-projectile-test-helper.el ends here

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -25,6 +25,7 @@
 
 (require 'helm-projectile)
 (require 'buttercup)
+(require 'helm-projectile-test-helper)
 
 (describe "helm-projectile package"
   (it "defines its core entry-point commands"
@@ -75,7 +76,94 @@
     (let ((result (helm-projectile--files-display-real
                    '("a.el" "src/b.el") "/proj/")))
       (expect (mapcar #'cdr result)
-              :to-equal '("/proj/a.el" "/proj/src/b.el")))))
+              :to-equal '("/proj/a.el" "/proj/src/b.el"))))
+
+  (it "keeps the directory component in the display of a nested file"
+    ;; Exercises the `file-name-directory' branch: a file in a subdirectory
+    ;; must keep its directory prefix in the display string, while a
+    ;; top-level file has none.
+    (let ((result (helm-projectile--files-display-real
+                   '("a.el" "src/b.el") "/proj/")))
+      (expect (substring-no-properties (car (nth 0 result))) :not :to-match "/")
+      (expect (substring-no-properties (car (nth 1 result))) :to-match "\\`src/"))))
+
+(describe "helm-projectile-hack-actions"
+  ;; Pure action-list surgery that drives which actions each source offers
+  ;; and in what order; every source's action list is built through it.
+  (let ((base '(("Open" . open-fn) ("Delete" . delete-fn) ("Rename" . rename-fn))))
+
+    (it "deletes an action named by a bare symbol"
+      (expect (helm-projectile-hack-actions base 'delete-fn)
+              :to-equal '(("Open" . open-fn) ("Rename" . rename-fn))))
+
+    (it "substitutes an action's function"
+      (expect (helm-projectile-hack-actions base '(open-fn . identity))
+              :to-equal '(("Open" . identity) ("Delete" . delete-fn) ("Rename" . rename-fn))))
+
+    (it "renames an existing action's description"
+      (expect (helm-projectile-hack-actions base '(open-fn . "Open file"))
+              :to-equal '(("Open file" . open-fn) ("Delete" . delete-fn) ("Rename" . rename-fn))))
+
+    (it "appends a new action for an unknown function"
+      (expect (helm-projectile-hack-actions base '(new-fn . "Brand new"))
+              :to-equal '(("Open" . open-fn) ("Delete" . delete-fn)
+                          ("Rename" . rename-fn) ("Brand new" . new-fn))))
+
+    (it "promotes an action to the front with :make-first"
+      (expect (helm-projectile-hack-actions base '(rename-fn . :make-first))
+              :to-equal '(("Rename" . rename-fn) ("Open" . open-fn) ("Delete" . delete-fn))))
+
+    (it "does not mutate the input action list"
+      (helm-projectile-hack-actions base 'delete-fn '(open-fn . "x") '(rename-fn . :make-first))
+      (expect base
+              :to-equal '(("Open" . open-fn) ("Delete" . delete-fn) ("Rename" . rename-fn))))))
+
+(describe "helm-projectile--wildcard-to-ack-match"
+  ;; Characterization tests: they pin the current glob->ack-regex transform
+  ;; (`.'->`\\.', `?'->`.', `*'->`.*', anchored with ^...$).
+  (it "escapes dots and expands glob wildcards, anchored"
+    (expect (helm-projectile--wildcard-to-ack-match "*.el") :to-equal "^.*\\.el$")
+    (expect (helm-projectile--wildcard-to-ack-match "foo?.txt") :to-equal "^foo.\\.txt$")
+    (expect (helm-projectile--wildcard-to-ack-match "*.min.js") :to-equal "^.*\\.min\\.js$")
+    (expect (helm-projectile--wildcard-to-ack-match "test_*.rb") :to-equal "^test_.*\\.rb$"))
+
+  (it "turns a leading [!...] negation into [^...]"
+    (expect (helm-projectile--wildcard-to-ack-match "[!x].c") :to-equal "^[^x]\\.c$")))
+
+(describe "helm-projectile--move-selection-p"
+  ;; Decides whether the selector should skip past a candidate to reach a
+  ;; real file.  Skip a plain non-existent pattern; stay on a real file or a
+  ;; non-string.
+  (it "returns non-nil for a plain non-existent pattern"
+    (expect (helm-projectile--move-selection-p "no-such-file-xyzzy.qqq") :to-be-truthy))
+
+  (it "returns nil for a non-string selection"
+    (expect (helm-projectile--move-selection-p nil) :not :to-be-truthy)
+    (expect (helm-projectile--move-selection-p 42) :not :to-be-truthy))
+
+  (it "returns nil for an existing file"
+    (helm-projectile-test-with-sandbox
+      (helm-projectile-test-with-files '("real.el")
+        (expect (helm-projectile--move-selection-p (expand-file-name "real.el"))
+                :not :to-be-truthy)))))
+
+(describe "helm-projectile-files-in-current-dired-buffer"
+  ;; Fixture-backed: build a throwaway project on disk and a *virtual* Dired
+  ;; buffer from an explicit file list (the way the dired-files actions do),
+  ;; then assert the helper reads those entries back as truenames.
+  (it "returns the truenames of the files listed in the Dired buffer"
+    (helm-projectile-test-with-sandbox
+      (helm-projectile-test-with-files '("a.el" "b.el")
+        (let ((buf (dired (cons "virtual-dired" '("a.el" "b.el")))))
+          (unwind-protect
+              (with-current-buffer buf
+                (expect (sort (helm-projectile-files-in-current-dired-buffer)
+                              #'string<)
+                        :to-equal
+                        (sort (list (file-truename (expand-file-name "a.el"))
+                                    (file-truename (expand-file-name "b.el")))
+                              #'string<)))
+            (kill-buffer buf)))))))
 
 (describe "helm-projectile streaming file source"
   (it "defines the streaming command and its source"
@@ -114,10 +202,6 @@
     (spy-on 'projectile-maybe-invalidate-cache)
     (spy-on 'projectile-project-name :and-return-value "demo")
     (spy-on 'projectile-prepend-project-name :and-call-fake #'identity))
-
-  (defun helm-projectile-test--sources ()
-    "Return the `:sources' passed to the most recent stubbed `helm' call."
-    (plist-get (spy-calls-args-for 'helm 0) :sources))
 
   (it "defaults to sync"
     (expect helm-projectile-find-file-strategy :to-be 'sync))


### PR DESCRIPTION
First of the test-suite improvements. The suite had no shared fixtures and left the package's non-trivial pure helpers completely untested.

This adds `test/helm-projectile-test-helper.el` with a temporary-project sandbox (`helm-projectile-test-with-sandbox` / `-with-files`, mirroring Projectile's own test helpers) plus the `:sources`-capturing shim that was previously buried inside a `describe` block. It then covers the logic most likely to break silently:

- `helm-projectile-hack-actions` - the action-list surgery (delete / substitute / rename / append / make-first) every source's action list is built through, including that it doesn't mutate its input
- `helm-projectile--wildcard-to-ack-match` - characterization of the glob->ack-regex transform (which carries a `FIXME`)
- `helm-projectile--move-selection-p` - the skip-to-real-candidate predicate
- `helm-projectile--files-display-real` - the nested-file display branch
- `helm-projectile-files-in-current-dired-buffer` - read back from a virtual Dired buffer built on a sandbox project

38 specs, up from 25. Follow-ups will cover the search-command construction and add coverage tooling.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing change)