### PR TITLE
Require Emacs 28.1 and Projectile 3.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Earliest supported + latest in each stable branch + snapshot.
-        emacs_version: ['27.2', '28.2', '29.4', '30.2', 'snapshot']
+        emacs_version: ['28.2', '29.4', '30.2', 'snapshot']
 
     steps:
     - name: Check out the source code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Require Emacs 28.1 and Projectile 3.1.0. Projectile 3.1.0 raised its own minimum to Emacs 28.1 (and pulls in `compat`), so helm-projectile can no longer be installed on Emacs 27. The CI matrix drops the 27.2 job accordingly.
+
 ## 1.6.0 (2026-07-01)
 
 ### New features

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -8,7 +8,7 @@
 ;; Created: 2011-31-07
 ;; Keywords: project, convenience
 ;; Version: 1.6.0
-;; Package-Requires: ((emacs "27.1") (helm "3.0") (projectile "2.9"))
+;; Package-Requires: ((emacs "28.1") (helm "3.0") (projectile "3.1.0"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Projectile 3.1.0 (released a few days ago) raised its own minimum to `(emacs "28.1")` and now depends on `compat`, so it can no longer be installed on Emacs 27 - which makes helm-projectile unusable there too. This surfaced as red CI: the 27.2 job fails at dependency resolution (`Emacs version 28.1 is required`) before running any tests, and fail-fast then cancels the rest of the matrix.

Follow projectile: bump the `Package-Requires` floor to Emacs 28.1 and Projectile 3.1.0, and drop the 27.2 job from the CI matrix.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no version mention there)