### PR TITLE
Test the search-command construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Internal
 
 * Add a shared test helper module (`test/helm-projectile-test-helper.el`) with a temporary-project sandbox, and broaden unit coverage of the pure helpers (`helm-projectile-hack-actions`, `helm-projectile--wildcard-to-ack-match`, `helm-projectile--move-selection-p`, `helm-projectile--files-display-real`) and `helm-projectile-files-in-current-dired-buffer`.
+* Cover the search-command construction: the grep/git-grep/ack command templates built by `helm-projectile-grep-or-ack`, the per-searcher ignore globs (`--ignore` vs `--glob !`) built by `helm-projectile--ag-1`, and the ignored-files/directories unions.
 
 ## 1.6.0 (2026-07-01)
 

--- a/test/helm-projectile-test-helper.el
+++ b/test/helm-projectile-test-helper.el
@@ -63,5 +63,31 @@ touched as an empty file.  Meant to be nested inside
 A `(spy-on \\='helm)' must be active for this to have anything to read."
   (plist-get (spy-calls-args-for 'helm (or n 0)) :sources))
 
+(defun helm-projectile-test--grep-command (&rest args)
+  "Return the `helm-grep-default-command' built by `helm-projectile-grep-or-ack'.
+ARGS are forwarded to it; `helm' is stubbed so nothing is displayed, and
+the ignore strategy is forced to `search-tool' to isolate the command
+string from Projectile's ignore computation."
+  (let (command)
+    (cl-letf (((symbol-function 'helm)
+               (lambda (&rest _) (setq command helm-grep-default-command))))
+      (let ((helm-projectile-ignore-strategy 'search-tool))
+        (apply #'helm-projectile-grep-or-ack args)))
+    command))
+
+(defun helm-projectile-test--ag-command (searcher &optional options)
+  "Return the `helm-grep-ag-command' built by `helm-projectile--ag-1'.
+SEARCHER is what `helm-grep--ag-command' should report (\"ag\", \"pt\" or
+\"rg\").  `helm-grep-ag' is stubbed and the command template reset to a
+plain three-slot string so only the ignore globs vary."
+  (let (command)
+    (cl-letf (((symbol-function 'helm-grep-ag)
+               (lambda (&rest _) (setq command helm-grep-ag-command)))
+              ((symbol-function 'helm-grep--ag-command) (lambda (&rest _) searcher)))
+      (let ((helm-projectile-ignore-strategy 'projectile)
+            (helm-grep-ag-command "ag %s %s %s"))
+        (helm-projectile--ag-1 "/proj/" nil options)))
+    command))
+
 (provide 'helm-projectile-test-helper)
 ;;; helm-projectile-test-helper.el ends here

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -295,6 +295,71 @@
       (expect (slot-value (helm-source-projectile-file :name "t") 'fuzzy-match)
               :to-be t))))
 
+(describe "helm-projectile ignore lists"
+  ;; The union of Projectile's ignores with the `grep-find-ignored-*'
+  ;; defaults feeds every search command; several past bugs lived here.
+  (before-each
+    (spy-on 'projectile-ignored-files-rel :and-return-value '("TAGS" "a.log"))
+    (spy-on 'projectile-ignored-directories-rel
+            :and-return-value '("build" "node_modules")))
+
+  (it "unions the Projectile and grep ignored files, de-duplicated"
+    (let ((grep-find-ignored-files '("*.o" "TAGS")))
+      (expect (sort (copy-sequence (helm-projectile--ignored-files)) #'string<)
+              :to-equal '("*.o" "TAGS" "a.log"))))
+
+  (it "unions ignored directories as directory names, de-duplicated"
+    (let ((grep-find-ignored-directories '(".git" "build")))
+      (expect (sort (copy-sequence (helm-projectile--ignored-directories)) #'string<)
+              :to-equal '(".git/" "build/" "node_modules/")))))
+
+(describe "helm-projectile-grep-or-ack command construction"
+  (before-each
+    (spy-on 'projectile-project-root :and-return-value "/proj/")
+    (spy-on 'projectile-project-vcs :and-return-value 'git))
+
+  (it "uses git grep in a git project when projectile-use-git-grep is on"
+    (let ((projectile-use-git-grep t))
+      (expect (helm-projectile-test--grep-command "/proj/" nil nil nil nil)
+              :to-equal helm-projectile-git-grep-command)))
+
+  (it "uses plain grep otherwise"
+    (let ((projectile-use-git-grep nil))
+      (expect (helm-projectile-test--grep-command "/proj/" nil nil nil nil)
+              :to-equal helm-projectile-grep-command)))
+
+  (it "strips the trailing directory from grep when an include is given"
+    (let ((projectile-use-git-grep nil))
+      (expect (helm-projectile-test--grep-command "/proj/" nil nil nil "*.el")
+              :to-equal "grep -a -r %e -n%cH -e %p %f")))
+
+  (it "builds an ack command, inserting the include and ignore slots"
+    (expect (helm-projectile-test--grep-command "/proj/" t nil "ack" nil)
+            :to-equal "ack -H --no-group --no-color %p %f")
+    (expect (helm-projectile-test--grep-command "/proj/" t "--type-add" "ack" "elisp")
+            :to-equal "ack -H --no-group --no-color %e --type-add %p %f")))
+
+(describe "helm-projectile--ag-1 ignore globs"
+  ;; The ignore syntax differs by searcher: ag/pt take `--ignore', rg takes
+  ;; `--glob !'.  Options are appended after the ignores, before the slots.
+  (before-each
+    (spy-on 'helm-projectile--ignored-files :and-return-value '("TAGS"))
+    (spy-on 'helm-projectile--ignored-directories :and-return-value '("build/")))
+
+  (it "uses --ignore for ag and pt"
+    (expect (helm-projectile-test--ag-command "ag")
+            :to-equal "ag --ignore TAGS --ignore build/ %s %s %s")
+    (expect (helm-projectile-test--ag-command "pt")
+            :to-equal "ag --ignore TAGS --ignore build/ %s %s %s"))
+
+  (it "uses --glob ! for rg"
+    (expect (helm-projectile-test--ag-command "rg")
+            :to-equal "ag --glob !TAGS --glob !build/ %s %s %s"))
+
+  (it "appends explicit options after the ignore globs"
+    (expect (helm-projectile-test--ag-command "ag" "--foo")
+            :to-equal "ag --ignore TAGS --ignore build/ --foo %s %s %s")))
+
 (describe "user-facing error conditions"
   ;; Normal situations (no project, no other file, ...) should signal
   ;; `user-error', not `error', so they don't trip the debugger when a user


### PR DESCRIPTION
The grep/ack/ag command building is helm-projectile's own logic and the source of several past bugs (per the changelog history), yet it had no tests. This covers it:

- the git-grep / grep / grep-with-include / ack command templates built by `helm-projectile-grep-or-ack`, including that supplying an include strips the trailing directory from the plain grep command
- the per-searcher ignore globs built by `helm-projectile--ag-1` (`--ignore` for ag/pt, `--glob !` for rg, with explicit options appended after the globs)
- the `helm-projectile--ignored-files` / `--ignored-directories` unions with the `grep-find-ignored-*` defaults

Two reusable capture helpers (stub the terminal `helm` / `helm-grep-ag` and read back the dynamically-bound command string) live in the test helper module. 47 specs, up from 38.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing change)