### PR TITLE
Measure test coverage with undercover + Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,27 @@ jobs:
       run: |
         eldev -p -dtT test
         eldev -dtT compile --warnings-as-errors
+
+  coverage:
+    runs-on: ubuntu-latest
+    container: silex/emacs:30.2-ci-eldev
+    # Coverage is informational - never let it block the build.
+    continue-on-error: true
+    steps:
+    - name: Check out the source code
+      uses: actions/checkout@v6
+
+    # `UNDERCOVER_FORCE' turns on the instrumentation in the test suite, and
+    # `--loading=source' makes Eldev load the .el (not the packaged .elc) so
+    # undercover can instrument it.  Writes coverage/lcov.info.
+    - name: Measure test coverage
+      env:
+        UNDERCOVER_FORCE: 'true'
+      run: eldev --loading=source -dtT test
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage/lcov.info
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.eldev/
 /Eldev-local
+/coverage/
 *.elc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Add a shared test helper module (`test/helm-projectile-test-helper.el`) with a temporary-project sandbox, and broaden unit coverage of the pure helpers (`helm-projectile-hack-actions`, `helm-projectile--wildcard-to-ack-match`, `helm-projectile--move-selection-p`, `helm-projectile--files-display-real`) and `helm-projectile-files-in-current-dired-buffer`.
 * Cover the search-command construction: the grep/git-grep/ack command templates built by `helm-projectile-grep-or-ack`, the per-searcher ignore globs (`--ignore` vs `--glob !`) built by `helm-projectile--ag-1`, and the ignored-files/directories unions.
+* Measure test coverage with `undercover` and report it to Codecov from a dedicated (non-blocking) CI job.
 
 ## 1.6.0 (2026-07-01)
 

--- a/Eldev
+++ b/Eldev
@@ -10,3 +10,9 @@
 
 ;; Buttercup is the test framework.
 (eldev-add-extra-dependencies 'test 'buttercup)
+
+;; `undercover' measures test coverage.  The test suite instruments the
+;; package with it (see `test/helm-projectile-test.el'), but it only does
+;; anything under CI or when `UNDERCOVER_FORCE' is set, so local runs are
+;; unaffected.
+(eldev-add-extra-dependencies 'test 'undercover)

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -23,6 +23,19 @@
 
 ;;; Code:
 
+;; Instrument the package for coverage when `UNDERCOVER_FORCE' is set (the CI
+;; coverage job sets it).  Eldev loads the package before the test files, so
+;; once `undercover' is watching `load' we re-load it from source to
+;; instrument it.  Gated on the env var so ordinary local runs and the main
+;; CI matrix are untouched; needs `--loading=source' to load the .el.
+(when (and (getenv "UNDERCOVER_FORCE")
+           (require 'undercover nil t))
+  (undercover "helm-projectile.el"
+              (:report-format 'lcov)
+              (:report-file "coverage/lcov.info")
+              (:send-report nil))
+  (load "helm-projectile" nil t))
+
 (require 'helm-projectile)
 (require 'buttercup)
 (require 'helm-projectile-test-helper)


### PR DESCRIPTION
Wires up `undercover` so coverage can be tracked and grown deliberately (the third of the test-suite improvements).

The fiddly part is that Eldev loads the package *before* the test files, so a plain `(undercover ...)` at the top of the test file is too late to instrument anything. The suite instead turns on undercover and re-loads `helm-projectile.el` from source (which is why the coverage job runs with `--loading=source`). It's gated on the `UNDERCOVER_FORCE` env var, so:

- ordinary local `eldev test` and the **main CI matrix are completely untouched** (no instrumentation, no reload);
- only the dedicated `coverage` CI job sets `UNDERCOVER_FORCE=true`, generates `coverage/lcov.info`, and uploads it to Codecov.

The coverage job is `continue-on-error: true` and the Codecov upload is `fail_ci_if_error: false`, so it can never block a build - it just stays green until you connect the repo to Codecov.

Baseline is ~24% line coverage (the suite is unit-focused; the interactive Helm/UI paths aren't exercised) - a real number to grow from.

### To finish enabling Codecov (your side)
- Add the repo on codecov.io and set a `CODECOV_TOKEN` repo secret (the workflow already passes it).
- Optionally add a coverage badge to the README.

Verified locally: `UNDERCOVER_FORCE=true eldev --loading=source -dtT test` produces the lcov report; a normal `eldev -p test` produces no report and is unaffected.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (deferred to the badge step, your call)