### PR TITLE
Drop the dead Elscreen grep/ack action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Require Emacs 28.1 and Projectile 3.1.0. Projectile 3.1.0 raised its own minimum to Emacs 28.1 (and pulls in `compat`), so helm-projectile can no longer be installed on Emacs 27. The CI matrix drops the 27.2 job accordingly.
+* Drop the dead "Find file in Elscreen" grep/ack action. Helm removed elscreen support (`helm-grep-jump-elscreen` no longer exists), so that action errored for anyone who still had elscreen installed.
 
 ### Internal
 

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1364,9 +1364,6 @@ When set to `search-tool', the above does not happen."
 (defcustom helm-projectile-grep-or-ack-actions
   '("Find file" helm-grep-action
     "Find file other frame" helm-grep-other-frame
-    (lambda () (and (locate-library "elscreen")
-               "Find file in Elscreen"))
-    helm-grep-jump-elscreen
     "Save results in grep buffer" helm-grep-save-results
     "Find file other window" helm-grep-other-window)
   "Available actions for `helm-projectile-grep-or-ack'.

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -308,6 +308,14 @@
       (expect (slot-value (helm-source-projectile-file :name "t") 'fuzzy-match)
               :to-be t))))
 
+(describe "helm-projectile-grep-or-ack-actions"
+  ;; Guard against dead action references: Helm dropped elscreen support, so
+  ;; every function named in the default action list must actually exist.
+  (it "names only functions that are defined"
+    (let ((actions (apply #'helm-make-actions helm-projectile-grep-or-ack-actions)))
+      (dolist (action actions)
+        (expect (fboundp (cdr action)) :to-be-truthy)))))
+
 (describe "helm-projectile ignore lists"
   ;; The union of Projectile's ignores with the `grep-find-ignored-*'
   ;; defaults feeds every search command; several past bugs lived here.


### PR DESCRIPTION
Part of the dead-feature audit. Helm removed elscreen support - `helm-grep-jump-elscreen` no longer exists in Helm 4.x. The "Find file in Elscreen" action in `helm-projectile-grep-or-ack-actions` was hidden unless elscreen happened to be installed (its label is computed via `locate-library`), but for anyone who still had elscreen it pointed at a void function and errored on selection.

Removes the label thunk and the dead action, and adds a test asserting that every action in the default list names a real function (so a future dead reference is caught).

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing change worth noting)