### PR TITLE
Deprecate helm-projectile-ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Require Emacs 28.1 and Projectile 3.1.0. Projectile 3.1.0 raised its own minimum to Emacs 28.1 (and pulls in `compat`), so helm-projectile can no longer be installed on Emacs 27. The CI matrix drops the 27.2 job accordingly.
 * Drop the dead "Find file in Elscreen" grep/ack action. Helm removed elscreen support (`helm-grep-jump-elscreen` no longer exists), so that action errored for anyone who still had elscreen installed.
+* Deprecate `helm-projectile-ack`. ack has been superseded by ripgrep and the silver searcher, and Projectile itself dropped `projectile-ack`; use `helm-projectile-rg` or `helm-projectile-ag` instead. The command still works for now but is marked obsolete and will be removed in a future release.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ these are the supported commands:
 * `helm-projectile-find-dir`
 * `helm-projectile-recentf`
 * `helm-projectile-switch-to-buffer`
-* `helm-projectile-grep` (can be used for both grep or ack)
+* `helm-projectile-grep`
+* `helm-projectile-ack` (deprecated - use `helm-projectile-rg` or `helm-projectile-ag`)
 * `helm-projectile-ag`
 * `helm-projectile-rg`
 * Replace Helm equivalent commands in `projectile-commander`

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -1596,7 +1596,11 @@ prefix argument then ask for FILES."
   "Run an ack search in the current project with Helm.
 DIR directory where to search, if not set then current project root is
 used.  TYPES is a list of types to include in search.  When called with
-a prefix argument, then ask for TYPES."
+a prefix argument, then ask for TYPES.
+
+This command is obsolete: ack has been superseded by ripgrep and the
+silver searcher, and Projectile itself has dropped `projectile-ack'.
+Use `helm-projectile-rg' or `helm-projectile-ag' instead."
   (interactive)
   (let* ((project-root (or dir (projectile-project-root) (user-error "You're not in a project")))
          (ignored (when (helm-projectile--projectile-ignore-strategy)
@@ -1629,6 +1633,10 @@ a prefix argument, then ask for TYPES."
                     types)))
     (run-with-timer 0.01 nil
              #'helm-projectile-grep-or-ack project-root t ignored helm-ack-grep-executable include)))
+
+(make-obsolete 'helm-projectile-ack
+               "use `helm-projectile-rg' or `helm-projectile-ag' instead."
+               "1.7.0")
 
 (defvar helm-projectile--ag-input nil
   "The value of input to be used in a next `helm-projectile-ag' call.")

--- a/test/helm-projectile-test.el
+++ b/test/helm-projectile-test.el
@@ -381,6 +381,12 @@
     (expect (helm-projectile-test--ag-command "ag" "--foo")
             :to-equal "ag --ignore TAGS --ignore build/ --foo %s %s %s")))
 
+(describe "helm-projectile-ack deprecation"
+  ;; ack is superseded by rg/ag and Projectile dropped `projectile-ack';
+  ;; the command is kept working but marked obsolete.
+  (it "is marked obsolete"
+    (expect (get 'helm-projectile-ack 'byte-obsolete-info) :to-be-truthy)))
+
 (describe "helm-projectile-ack"
   (before-each
     (spy-on 'projectile-project-root :and-return-value "/proj/")


### PR DESCRIPTION
Follow-up from the dead/obsolete audit. ack is legacy: it's been superseded by ripgrep and the silver searcher (both already supported via `helm-projectile-rg` / `helm-projectile-ag`), and **Projectile itself dropped `projectile-ack`** - so `helm-projectile-ack` now shadows a command that no longer exists upstream, and it was only reachable via `M-x` (the toggle remaps grep/ag/ripgrep, not ack).

Rather than remove it outright, this marks it obsolete via `make-obsolete` (pointing at rg/ag), with a docstring note and README/CHANGELOG entries. It keeps working for the 1.7.0 cycle; the `use-ack-p` machinery in `helm-projectile-grep-or-ack` and `helm-projectile--wildcard-to-ack-match` will be removed together with the command in a future release.

A test asserts the command carries obsolete info.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [x] You've updated the readme