### PR TITLE
Make the grep dependency honest; drop unused requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ### Internal
 
+* Tidy up top-level dependencies: `require` `grep` from the helpers that actually use `grep-find-ignored-files`/`-directories` (`helm-projectile--ignored-files`/`-directories`) instead of relying on it being pulled in transitively, and drop the unused `helm-locate` and `helm-global-bindings` requires. (No startup-time change - Helm loads all three transitively anyway; this just makes the dependencies honest.)
 * Drive `helm-projectile-toggle`'s command remaps from a single table (`helm-projectile--command-remaps`) instead of two hand-maintained copies of ~20 `define-key` calls.
 * Extract the remote virtual-Dired guard duplicated across the three Dired file actions into a `helm-projectile--with-virtual-dired` macro.
 * Sharp-quote (`#'`) function references so the byte-compiler can catch typos in them.

--- a/helm-projectile.el
+++ b/helm-projectile.el
@@ -43,12 +43,11 @@
 ;; built-in libraries
 (require 'subr-x)
 (require 'cl-lib)
-(require 'grep) ;; TODO: Probably we should defer this require
+;; `grep' is loaded lazily (only when computing ignores for a search); see
+;; `helm-projectile--ignored-files'.
 
 (require 'helm-core)
-(require 'helm-global-bindings)
 (require 'helm-types)
-(require 'helm-locate)
 (require 'helm-buffers)
 (require 'helm-files)
 (require 'helm-grep)
@@ -1441,11 +1440,15 @@ When set to `search-tool', the above does not happen."
 
 (defun helm-projectile--ignored-files ()
   "Compute ignored files."
+  ;; `grep' provides `grep-find-ignored-files'; load it on demand rather than
+  ;; at startup, since it is only needed when a search computes ignores.
+  (require 'grep)
   (cl-union (projectile-ignored-files-rel) grep-find-ignored-files
             :test #'equal))
 
 (defun helm-projectile--ignored-directories ()
   "Compute ignored directories."
+  (require 'grep)
   (cl-union (mapcar #'file-name-as-directory (projectile-ignored-directories-rel))
             (mapcar #'file-name-as-directory grep-find-ignored-directories)
             :test #'equal))


### PR DESCRIPTION
This was #2 on the list ("defer the eager requires for startup"), but the investigation changed the conclusion, so the scope is smaller and honestly framed.

**Finding:** the eager requires can't be deferred for a startup win. helm-projectile builds Helm sources at load (top-level `defclass`/`helm-make-source`), so Helm is a hard load-time dependency, and Helm's own module graph transitively loads `grep`, `helm-locate` and `helm-global-bindings` regardless. I verified `(featurep 'grep)` etc. are all `t` right after `(require 'helm-projectile)` even with the explicit requires removed. Deferring would need every source definition restructured to be lazy - too big/risky for the payoff.

**What this does instead** (dependency hygiene, no perf claim):
- `require 'grep` from `helm-projectile--ignored-files` / `-directories`, the two helpers that actually read `grep-find-ignored-files`/`-directories`, so they're self-sufficient instead of relying on a transitive load that could change. (Also finally retires the years-old `TODO: defer this require`.)
- Drop the `helm-locate` and `helm-global-bindings` requires - nothing here uses a symbol from either.

Load cost is unchanged; the dependencies are just honest now. Compile (warnings-as-errors), checkdoc and 66 specs all pass.

- [x] The commits are consistent with our contribution guidelines
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog
- [ ] You've updated the readme (no user-facing change)